### PR TITLE
Fix biome dependency and erroring log

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.13.8",
-    "biome": "^0.3.3",
+    "@biomejs/biome": "^1.9.4",
     "typescript": "^5.8.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ const server = new McpServer({
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log('Spotify MCP Server running on stdio');
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Saw a couple issues when using the mcp:

* the biome dependency had vulnerabilities it used https://www.npmjs.com/package/biome instead of the probably intended biomejs
* The console.log in the main goes to claude desktop so it results in annoying errors https://modelcontextprotocol.io/docs/tools/debugging?utm_source=chatgpt.com#implementing-logging I thought the easier solution is just to drop it instead of adding pino/winston for logging here...