### PR TITLE
feat: list your recently played tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
    - **Example**: `getMyPlaylists(10, 0)`
 
 4. **getPlaylistTracks**
+
    - **Description**: Get a list of tracks in a specific Spotify playlist
    - **Parameters**:
      - `playlistId` (string): The Spotify ID of the playlist
@@ -66,6 +67,22 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
      - `offset` (number, optional): Index of the first track to return (default: 0)
    - **Returns**: Array of tracks with their IDs, names, artists, album, duration, and added date
    - **Example**: `getPlaylistTracks("37i9dQZEVXcJZyENOWUFo7")`
+
+5. **getRecentlyPlayed**
+
+   - **Description**: Retrieves a list of recently played tracks from Spotify.
+   - **Parameters**:
+     - `limit` (number, optional): A number specifying the maximum number of tracks to return.
+   - **Returns**: If tracks are found it returns a formatted list of recently played tracks else a message stating: "You don't have any recently played tracks on Spotify".
+   - **Example**: `getRecentlyPlayed({ limit: 10 })`
+
+6. **getRecentlyPlayed**
+
+   - **Description**: Retrieves a list of recently played tracks from Spotify.
+   - **Parameters**:
+     - `limit` (number, optional): A number specifying the maximum number of tracks to return.
+   - **Returns**: If tracks are found it returns a formatted list of recently played tracks else a message stating: "You don't have any recently played tracks on Spotify".
+   - **Example**: `getRecentlyPlayed({ limit: 10 })`
 
 ### Play / Create Operations
 
@@ -116,6 +133,7 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
    - **Example**: `createPlaylist({ name: "Workout Mix", description: "Songs to get pumped up", public: false })`
 
 6. **addTracksToPlaylist**
+
    - **Description**: Add tracks to an existing Spotify playlist
    - **Parameters**:
      - `playlistId` (string): ID of the playlist
@@ -124,7 +142,8 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
    - **Returns**: Success status and snapshot ID
    - **Example**: `addTracksToPlaylist({ playlistId: "3cEYpjA9oz9GiPac4AsH4n", trackUris: ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh"] })`
 
-6. **addToQueue**
+7. **addToQueue**
+
    - **Description**: Adds a track, album, artist or playlist to the current playback queue
    - - **Parameters**:
      - `uri` (string, optional): Spotify URI of the item to add to queue (overrides type and id)
@@ -236,3 +255,19 @@ For Cursor, go to the MCP tab in `Cursor Settings` (command + shift + J). Add a 
 ```bash
 node path/to/spotify-mcp-server/build/index.js
 ```
+
+To set up your MCP correctly with Cline ensure you have the following file configuration set `cline_mcp_settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "spotify": {
+      "command": "node",
+      "args": ["~/../spotify-mcp-server/build/index.js"],
+      "autoApprove": ["getListeningHistory", "getNowPlaying"]
+    }
+  }
+}
+```
+
+You can add additional tools to the auto approval array to run the tools without intervention.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
   - [Creating a Spotify Developer Application](#creating-a-spotify-developer-application)
   - [Spotify API Configuration](#spotify-api-configuration)
   - [Authentication Process](#authentication-process)
-- [Integrating with Claude Desktop and Cursor](#integrating-with-claude-desktop-and-cursor)
-- 
+- [Integrating with Claude Desktop, Cursor, and VsCode (Cline)](#integrating-with-claude-desktop-and-cursor)
 </details>
 
 ## Example Interactions
@@ -235,7 +234,7 @@ npm run auth
 
 7. The server will automatically refresh the access token when needed, using the refresh token.
 
-## Integrating with Claude Desktop and Cursor
+## Integrating with Claude Desktop, Cursor, and VsCode [Via Cline model extension](https://marketplace.visualstudio.com/items/?itemName=saoudrizwan.claude-dev)
 
 To use your MCP server with Claude Desktop, add it to your Claude configuration:
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,7 +137,7 @@ export async function authorizeSpotify(): Promise<void> {
     console.error(
       'Please update your spotify-config.json with a localhost redirect URI',
     );
-    console.error('Example: http://localhost:8888/callback');
+    console.error('Example: http://127.0.0.1:8888/callback');
     process.exit(1);
   }
 
@@ -157,6 +157,7 @@ export async function authorizeSpotify(): Promise<void> {
     'playlist-modify-public',
     'user-library-read',
     'user-library-modify',
+    'user-read-recently-played',
   ];
 
   const authParams = new URLSearchParams({


### PR DESCRIPTION
This PR is responsible for the following additions:
- Corrections and Additions to the Markdown ReadME
- Adds the new recently played tool to the read tools
- Adds the new scopes to auth util

I have updated the example console log to match the new URL requirements that Spotify has requested as of the 9th of April.

=> https://developer.spotify.com/documentation/web-api/concepts/redirect_uri

Below is a validation screenshot of the tool functioning correctly within VsCode (Cline)

![Screenshot 2025-04-10 at 00 50 17](https://github.com/user-attachments/assets/f76c8a7e-b33a-42a0-8911-86c968415b1f)