### PR TITLE
fix: improve OAuth flow with 127.0.0.1 redirect and show_dialog optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ npm run build
 5. Accept the Terms of Service and click "Create"
 6. In your new app's dashboard, you'll see your **Client ID**
 7. Click "Show Client Secret" to reveal your **Client Secret**
-8. Click "Edit Settings" and add a Redirect URI (e.g., `http://localhost:8888/callback`)
+8. Click "Edit Settings" and add a Redirect URI (e.g., `http://127.0.0.1:8888/callback`)
 9. Save your changes
 
 ### Spotify API Configuration
@@ -199,7 +199,7 @@ Then edit the file with your credentials:
 {
   "clientId": "your-client-id",
   "clientSecret": "your-client-secret",
-  "redirectUri": "http://localhost:8888/callback"
+  "redirectUri": "http://127.0.0.1:8888/callback"
 }
 ```
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,7 +169,7 @@ export async function authorizeSpotify(): Promise<void> {
     redirect_uri: config.redirectUri,
     scope: scopes.join(' '),
     state: state,
-    show_dialog: 'true',
+    show_dialog: 'false',
   });
 
   const authorizationUrl = `https://accounts.spotify.com/authorize?${authParams.toString()}`;


### PR DESCRIPTION
- Replace localhost with 127.0.0.1 in redirect URI (Spotify compatibility fix)
- Set show_dialog to false to skip unnecessary auth prompts for returning users
- Ensures smooth authentication while maintaining security