### PR TITLE
Add getQueue tool to fetch current and upcoming Spotify queue

### DIFF
--- a/src/read.ts
+++ b/src/read.ts
@@ -525,8 +525,6 @@ const getQueue: tool<{
   },
 };
 
-
-
 export const readTools = [
   searchSpotify,
   getNowPlaying,


### PR DESCRIPTION
Displays the next items in the queue, with support for a configurable limit (1–50)