### PR TITLE
feat: add getUsersTopItems tool to fetch user's top artists or tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,18 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
    - **Returns**: If tracks are found it returns a formatted list of recently played tracks else a message stating: "You don't have any recently played tracks on Spotify".
    - **Example**: `getRecentlyPlayed({ limit: 10 })`
 
-6. **getUsersSavedTracks**
+6. **getUsersTopItems**
+
+   - **Description**: Get the current user's top artists or tracks based on calculated affinity (listening history). Requires the `user-top-read` scope.
+   - **Parameters**:
+     - `type` (string): Whether to return top artists or top tracks (`"artists"` or `"tracks"`)
+     - `time_range` (string, optional): Time frame — `short_term` (~4 weeks), `medium_term` (~6 months), `long_term` (~1 year). Default: `medium_term`
+     - `limit` (number, optional): Maximum number of items to return (1-50, default: 20)
+     - `offset` (number, optional): Index of first item for pagination (default: 0)
+   - **Returns**: Formatted list of top artists (name, ID) or tracks (name, artists, duration, ID) for the chosen time range
+   - **Example**: `getUsersTopItems({ type: "tracks", time_range: "short_term", limit: 10 })`
+
+7. **getUsersSavedTracks**
 
    - **Description**: Get a list of tracks saved in the user's "Liked Songs" library
    - **Parameters**:
@@ -87,7 +98,7 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
    - **Returns**: Formatted list of saved tracks with track names, artists, duration, track IDs, and when they were added to Liked Songs. Shows pagination info (e.g., "1-20 of 150").
    - **Example**: `getUsersSavedTracks({ limit: 20, offset: 0 })`
 
-7. **getQueue**
+8. **getQueue**
 
    - **Description**: Get the currently playing track and upcoming items in the Spotify queue
    - **Parameters**:
@@ -95,14 +106,14 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
    - **Returns**: Currently playing track and list of upcoming tracks in the queue
    - **Example**: `getQueue({ limit: 20 })`
 
-8. **getAvailableDevices**
+9. **getAvailableDevices**
 
    - **Description**: Get information about the user's available Spotify Connect devices
    - **Parameters**: None
    - **Returns**: List of available devices with name, type, active status, volume, and device ID
    - **Example**: `getAvailableDevices()`
 
-9. **removeUsersSavedTracks**
+10. **removeUsersSavedTracks**
 
    - **Description**: Remove one or more tracks from the user's "Liked Songs" library (max 40 per request)
    - **Parameters**:

--- a/src/read.ts
+++ b/src/read.ts
@@ -386,6 +386,114 @@ const getRecentlyPlayed: tool<{
   },
 };
 
+const getUsersTopItems: tool<{
+  type: z.ZodEnum<['artists', 'tracks']>;
+  time_range: z.ZodOptional<
+    z.ZodEnum<['short_term', 'medium_term', 'long_term']>
+  >;
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getUsersTopItems',
+  description:
+    "Get the current user's top artists or tracks based on calculated affinity (listening history). Requires user-top-read scope.",
+  schema: {
+    type: z
+      .enum(['artists', 'tracks'])
+      .describe('Whether to return top artists or top tracks'),
+    time_range: z
+      .enum(['short_term', 'medium_term', 'long_term'])
+      .optional()
+      .describe(
+        'Time frame: short_term (~4 weeks), medium_term (~6 months), long_term (~1 year). Default: medium_term',
+      ),
+    limit: z
+      .number()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe('Maximum number of items to return (1-50). Default: 20'),
+    offset: z
+      .number()
+      .min(0)
+      .optional()
+      .describe('Index of first item for pagination. Default: 0'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { type, time_range, limit = 20, offset = 0 } = args;
+
+    try {
+      const result = await handleSpotifyRequest(async (spotifyApi) => {
+        return await spotifyApi.currentUser.topItems(
+          type,
+          time_range,
+          limit as MaxInt<50>,
+          offset,
+        );
+      });
+
+      if (!result.items || result.items.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `No top ${type} data available. Listening history may be insufficient for the selected time range.`,
+            },
+          ],
+        };
+      }
+
+      const timeLabel =
+        time_range === 'long_term'
+          ? '~1 year'
+          : time_range === 'short_term'
+            ? '~4 weeks'
+            : '~6 months';
+
+      let formatted = '';
+      if (type === 'artists') {
+        formatted = (result.items as any[])
+          .map(
+            (artist: { name: string; id: string }, i: number) =>
+              `${offset + i + 1}. ${artist.name} - ID: ${artist.id}`,
+          )
+          .join('\n');
+      } else {
+        formatted = (result.items as any[])
+          .map((track: any, i: number) => {
+            if (!track || track.type !== 'track') return `${offset + i + 1}. [Unknown]`;
+            const artists = Array.isArray(track.artists)
+              ? track.artists.map((a: { name: string }) => a.name).join(', ')
+              : 'Unknown';
+            const duration = formatDuration(track.duration_ms ?? 0);
+            return `${offset + i + 1}. "${track.name}" by ${artists} (${duration}) - ID: ${track.id}`;
+          })
+          .join('\n');
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `# Your Top ${type === 'artists' ? 'Artists' : 'Tracks'} (${timeLabel})\n\n${formatted}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error fetching top ${type}: ${
+              error instanceof Error ? error.message : String(error)
+            }. Ensure the user-top-read scope is granted.`,
+          },
+        ],
+      };
+    }
+  },
+};
+
 const getUsersSavedTracks: tool<{
   limit: z.ZodOptional<z.ZodNumber>;
   offset: z.ZodOptional<z.ZodNumber>;
@@ -676,6 +784,7 @@ export const readTools = [
   getMyPlaylists,
   getPlaylistTracks,
   getRecentlyPlayed,
+  getUsersTopItems,
   getUsersSavedTracks,
   removeUsersSavedTracks,
   getQueue,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -226,6 +226,7 @@ export async function authorizeSpotify(): Promise<void> {
     'user-library-read',
     'user-library-modify',
     'user-read-recently-played',
+    'user-top-read',
     'user-modify-playback-state',
     'user-read-playback-state',
     'user-read-currently-playing',


### PR DESCRIPTION
## Summary

Adds a new read tool **getUsersTopItems** that returns the current user's top artists or tracks from the [Spotify Web API "Get User's Top Items"](https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks) endpoint, so MCP clients (e.g. AI assistants) can read the user's listening affinity over configurable time ranges.

## Changes

- `**src/read.ts`**
  - New tool `getUsersTopItems` with parameters: `type` (`"artists"` | `"tracks"`), optional `time_range` (`short_term` / `medium_term` / `long_term`), optional `limit` (1–50), optional `offset` for pagination.
  - Uses `spotifyApi.currentUser.topItems()` and returns a formatted list (artists: name + ID; tracks: name, artists, duration, ID).
  - Registered in the `readTools` array.
- `**src/utils.ts**`
  - Added `user-top-read` to the OAuth scopes so the new endpoint is allowed.
- `**README.md**`
  - Documented `getUsersTopItems` in the Read Operations section and renumbered the following tools (7–10).

## Notes for maintainers

- **New scope:** Existing users need to re-run the auth flow and approve the new `user-top-read` scope for this tool to work.
- Implementation and parameter behavior follow the [official API reference](https://developer.spotify.com/documentation/web-api/reference/get-users-top-artists-and-tracks).