### PR TITLE
security: harden OAuth flow, input validation, and token storage

### DIFF
--- a/src/albums.ts
+++ b/src/albums.ts
@@ -11,7 +11,7 @@ const getAlbums: tool<{
     'Get detailed information about one or more albums by their Spotify IDs',
   schema: {
     albumIds: z
-      .union([z.string(), z.array(z.string()).max(20)])
+      .union([z.string().max(500), z.array(z.string().max(500)).max(20)])
       .describe('A single album ID or array of album IDs (max 20)'),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
@@ -104,7 +104,7 @@ const getAlbumTracks: tool<{
   name: 'getAlbumTracks',
   description: 'Get tracks from a specific album with pagination support',
   schema: {
-    albumId: z.string().describe('The Spotify ID of the album'),
+    albumId: z.string().max(500).describe('The Spotify ID of the album'),
     limit: z
       .number()
       .min(1)
@@ -182,7 +182,7 @@ const saveOrRemoveAlbumForUser: tool<{
   description: 'Save or remove albums from the user\'s "Your Music" library',
   schema: {
     albumIds: z
-      .array(z.string())
+      .array(z.string().max(500))
       .max(20)
       .describe('Array of Spotify album IDs (max 20)'),
     action: z
@@ -243,7 +243,7 @@ const checkUsersSavedAlbums: tool<{
   description: 'Check if albums are saved in the user\'s "Your Music" library',
   schema: {
     albumIds: z
-      .array(z.string())
+      .array(z.string().max(500))
       .max(20)
       .describe('Array of Spotify album IDs to check (max 20)'),
   },

--- a/src/play.ts
+++ b/src/play.ts
@@ -20,7 +20,11 @@ const playMusic: tool<{
       .enum(['track', 'album', 'artist', 'playlist'])
       .optional()
       .describe('The type of item to play'),
-    id: z.string().max(500).optional().describe('The Spotify ID of the item to play'),
+    id: z
+      .string()
+      .max(500)
+      .optional()
+      .describe('The Spotify ID of the item to play'),
     deviceId: z
       .string()
       .max(500)
@@ -218,7 +222,9 @@ const addTracksToPlaylist: tool<{
   description: 'Add tracks to a Spotify playlist',
   schema: {
     playlistId: z.string().max(500).describe('The Spotify ID of the playlist'),
-    trackIds: z.array(z.string().max(500)).describe('Array of Spotify track IDs to add'),
+    trackIds: z
+      .array(z.string().max(500))
+      .describe('Array of Spotify track IDs to add'),
     position: z
       .number()
       .nonnegative()
@@ -323,7 +329,11 @@ const addToQueue: tool<{
       .enum(['track', 'album', 'artist', 'playlist'])
       .optional()
       .describe('The type of item to play'),
-    id: z.string().max(500).optional().describe('The Spotify ID of the item to play'),
+    id: z
+      .string()
+      .max(500)
+      .optional()
+      .describe('The Spotify ID of the item to play'),
     deviceId: z
       .string()
       .max(500)

--- a/src/play.ts
+++ b/src/play.ts
@@ -13,15 +13,17 @@ const playMusic: tool<{
   schema: {
     uri: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify URI to play (overrides type and id)'),
     type: z
       .enum(['track', 'album', 'artist', 'playlist'])
       .optional()
       .describe('The type of item to play'),
-    id: z.string().optional().describe('The Spotify ID of the item to play'),
+    id: z.string().max(500).optional().describe('The Spotify ID of the item to play'),
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to play on'),
   },
@@ -81,6 +83,7 @@ const pausePlayback: tool<{
   schema: {
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to pause playback on'),
   },
@@ -110,6 +113,7 @@ const skipToNext: tool<{
   schema: {
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to skip on'),
   },
@@ -140,6 +144,7 @@ const skipToPrevious: tool<{
   schema: {
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to skip on'),
   },
@@ -169,9 +174,10 @@ const createPlaylist: tool<{
   name: 'createPlaylist',
   description: 'Create a new playlist on Spotify',
   schema: {
-    name: z.string().describe('The name of the playlist'),
+    name: z.string().max(500).describe('The name of the playlist'),
     description: z
       .string()
+      .max(500)
       .optional()
       .describe('The description of the playlist'),
     public: z
@@ -211,8 +217,8 @@ const addTracksToPlaylist: tool<{
   name: 'addTracksToPlaylist',
   description: 'Add tracks to a Spotify playlist',
   schema: {
-    playlistId: z.string().describe('The Spotify ID of the playlist'),
-    trackIds: z.array(z.string()).describe('Array of Spotify track IDs to add'),
+    playlistId: z.string().max(500).describe('The Spotify ID of the playlist'),
+    trackIds: z.array(z.string().max(500)).describe('Array of Spotify track IDs to add'),
     position: z
       .number()
       .nonnegative()
@@ -277,6 +283,7 @@ const resumePlayback: tool<{
   schema: {
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to resume playback on'),
   },
@@ -309,15 +316,17 @@ const addToQueue: tool<{
   schema: {
     uri: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify URI to play (overrides type and id)'),
     type: z
       .enum(['track', 'album', 'artist', 'playlist'])
       .optional()
       .describe('The type of item to play'),
-    id: z.string().optional().describe('The Spotify ID of the item to play'),
+    id: z.string().max(500).optional().describe('The Spotify ID of the item to play'),
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to add the track to'),
   },
@@ -374,6 +383,7 @@ const setVolume: tool<{
       .describe('The volume to set (0-100)'),
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to set volume on'),
   },
@@ -428,6 +438,7 @@ const adjustVolume: tool<{
       ),
     deviceId: z
       .string()
+      .max(500)
       .optional()
       .describe('The Spotify device ID to adjust volume on'),
   },

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -9,7 +9,7 @@ const getPlaylist: tool<{
   description:
     'Get details of a specific Spotify playlist including tracks count, description and owner',
   schema: {
-    playlistId: z.string().describe('The Spotify ID of the playlist'),
+    playlistId: z.string().max(500).describe('The Spotify ID of the playlist'),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { playlistId } = args;
@@ -70,10 +70,11 @@ const updatePlaylist: tool<{
   description:
     'Update the details of a Spotify playlist (name, description, public/private, collaborative)',
   schema: {
-    playlistId: z.string().describe('The Spotify ID of the playlist'),
-    name: z.string().optional().describe('New name for the playlist'),
+    playlistId: z.string().max(500).describe('The Spotify ID of the playlist'),
+    name: z.string().max(500).optional().describe('New name for the playlist'),
     description: z
       .string()
+      .max(500)
       .optional()
       .describe('New description for the playlist'),
     public: z
@@ -156,14 +157,15 @@ const removeTracksFromPlaylist: tool<{
   description:
     'Remove one or more tracks from a Spotify playlist (max 100 tracks per request)',
   schema: {
-    playlistId: z.string().describe('The Spotify ID of the playlist'),
+    playlistId: z.string().max(500).describe('The Spotify ID of the playlist'),
     trackIds: z
-      .array(z.string())
+      .array(z.string().max(500))
       .min(1)
       .max(100)
       .describe('Array of Spotify track IDs to remove (max 100)'),
     snapshotId: z
       .string()
+      .max(500)
       .optional()
       .describe(
         'The playlist snapshot ID to target a specific version (optional)',
@@ -218,7 +220,7 @@ const reorderPlaylistItems: tool<{
   description:
     'Reorder a range of tracks within a Spotify playlist by moving them to a new position',
   schema: {
-    playlistId: z.string().describe('The Spotify ID of the playlist'),
+    playlistId: z.string().max(500).describe('The Spotify ID of the playlist'),
     rangeStart: z
       .number()
       .nonnegative()
@@ -236,6 +238,7 @@ const reorderPlaylistItems: tool<{
       .describe('Number of consecutive items to move (defaults to 1)'),
     snapshotId: z
       .string()
+      .max(500)
       .optional()
       .describe(
         'The playlist snapshot ID to target a specific version (optional)',

--- a/src/read.ts
+++ b/src/read.ts
@@ -26,7 +26,7 @@ const searchSpotify: tool<{
   name: 'searchSpotify',
   description: 'Search for tracks, albums, artists, or playlists on Spotify',
   schema: {
-    query: z.string().describe('The search query'),
+    query: z.string().max(500).describe('The search query'),
     type: z
       .enum(['track', 'album', 'artist', 'playlist'])
       .describe(
@@ -261,7 +261,7 @@ const getPlaylistTracks: tool<{
   name: 'getPlaylistTracks',
   description: 'Get a list of tracks in a Spotify playlist',
   schema: {
-    playlistId: z.string().describe('The Spotify ID of the playlist'),
+    playlistId: z.string().max(500).describe('The Spotify ID of the playlist'),
     limit: z
       .number()
       .min(1)
@@ -613,7 +613,7 @@ const removeUsersSavedTracks: tool<{
     'Remove one or more tracks from the user\'s "Liked Songs" library (max 40 per request)',
   schema: {
     trackIds: z
-      .array(z.string())
+      .array(z.string().max(500))
       .max(40)
       .describe('Array of Spotify track IDs to remove (max 40)'),
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
+import net from 'node:net';
 import path from 'node:path';
 import { URL, fileURLToPath } from 'node:url';
 import { SpotifyApi } from '@spotify/web-api-ts-sdk';
@@ -44,6 +45,7 @@ export function loadSpotifyConfig(): SpotifyConfig {
 
 export function saveSpotifyConfig(config: SpotifyConfig): void {
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), 'utf8');
+  fs.chmodSync(CONFIG_FILE, 0o600);
 }
 
 let cachedSpotifyApi: SpotifyApi | null = null;
@@ -117,6 +119,28 @@ function generateRandomString(length: number): string {
 function base64Encode(str: string): string {
   return Buffer.from(str).toString('base64');
 }
+
+function checkPortInUse(port: number, host: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    socket.setTimeout(1000);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once('error', () => {
+      resolve(false);
+    });
+    socket.connect(port, host);
+  });
+}
+
+const rateLimitMap = new Map<string, number>();
+const RATE_LIMIT_MS = 200;
 
 async function exchangeCodeForToken(
   code: string,
@@ -319,23 +343,38 @@ export async function authorizeSpotify(): Promise<void> {
       }
     });
 
-    server.listen(Number.parseInt(port), '127.0.0.1', () => {
-      console.log(
-        `Listening for Spotify authentication callback on port ${port}`,
-      );
-      console.log('Opening browser for authorization...');
-
-      open(authorizationUrl).catch((_error: Error) => {
-        console.log(
-          'Failed to open browser automatically. Please visit this URL to authorize:',
+    const portNum = Number.parseInt(port);
+    checkPortInUse(portNum, '127.0.0.1').then((inUse) => {
+      if (inUse) {
+        reject(
+          new Error(
+            `Port ${portNum} is already in use. Cannot start OAuth callback server.`,
+          ),
         );
-        console.log(authorizationUrl);
-      });
-    });
+        return;
+      }
 
-    server.on('error', (error) => {
-      console.error(`Server error: ${error.message}`);
-      reject(error);
+      server.listen(
+        { port: portNum, host: '127.0.0.1', exclusive: true },
+        () => {
+          console.log(
+            `Listening for Spotify authentication callback on port ${port}`,
+          );
+          console.log('Opening browser for authorization...');
+
+          open(authorizationUrl).catch((_error: Error) => {
+            console.log(
+              'Failed to open browser automatically. Please visit this URL to authorize:',
+            );
+            console.log(authorizationUrl);
+          });
+        },
+      );
+
+      server.on('error', (error) => {
+        console.error(`Server error: ${error.message}`);
+        reject(error);
+      });
     });
   });
 
@@ -351,6 +390,13 @@ export function formatDuration(ms: number): string {
 export async function handleSpotifyRequest<T>(
   action: (spotifyApi: SpotifyApi) => Promise<T>,
 ): Promise<T> {
+  const now = Date.now();
+  const lastCall = rateLimitMap.get('global');
+  if (lastCall && now - lastCall < RATE_LIMIT_MS) {
+    throw new Error('Rate limit exceeded');
+  }
+  rateLimitMap.set('global', now);
+
   try {
     const spotifyApi = await createSpotifyApi();
     return await action(spotifyApi);


### PR DESCRIPTION
## Summary

Security hardening of the OAuth authentication flow, Zod input schemas, and credential storage.

### Changes

- **Config file permissions**: `saveSpotifyConfig()` now sets `0600` permissions after write, preventing other system users from reading OAuth tokens
- **Exclusive port binding**: OAuth callback server uses `exclusive: true` and pre-checks port availability to prevent port hijacking during the auth flow
- **Input length bounds**: Added `.max(500)` to all unbounded string Zod schemas across `read.ts`, `play.ts`, `playlist.ts`, and `albums.ts` (30 schemas total) to prevent oversized inputs
- **Rate limiting**: Added 200ms cooldown between API calls via `handleSpotifyRequest` to prevent abuse from rapid tool invocations

### Test plan

- [ ] Verify `npm run auth` completes the OAuth flow successfully
- [ ] Verify `spotify-config.json` is created with `0600` permissions
- [ ] Verify search queries longer than 500 characters are rejected by Zod
- [ ] Verify rapid successive tool calls are rate-limited
- [ ] Verify all existing functionality works unchanged