### PR TITLE
fix playlist item endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,34 @@ const server = new McpServer({
 
 [...readTools, ...playTools, ...albumTools, ...playlistTools].forEach(
   (tool) => {
-    server.tool(tool.name, tool.description, tool.schema, tool.handler);
+    const safeHandler = tool.handler as (
+      args: unknown,
+      extra: unknown,
+    ) => Promise<{ content: Array<{ type: 'text'; text: string }> }> | {
+      content: Array<{ type: 'text'; text: string }>;
+    };
+
+    server.tool(
+      tool.name,
+      tool.description,
+      tool.schema,
+      async (args: unknown, extra: unknown) => {
+        try {
+          return await safeHandler(args, extra);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error in ${tool.name}: ${message}`,
+              },
+            ],
+          };
+        }
+      },
+    );
   },
 );
 

--- a/src/play.ts
+++ b/src/play.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, spotifyApiRequest } from './utils.js';
 
 const playMusic: tool<{
   uri: z.ZodOptional<z.ZodString>;
@@ -236,13 +236,16 @@ const addTracksToPlaylist: tool<{
     try {
       const trackUris = trackIds.map((id) => `spotify:track:${id}`);
 
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.addItemsToPlaylist(
-          playlistId,
-          trackUris,
-          position,
-        );
-      });
+      await spotifyApiRequest<{ snapshot_id: string }>(
+        `/playlists/${playlistId}/items`,
+        {
+          method: 'POST',
+          body: {
+            uris: trackUris,
+            ...(position !== undefined ? { position } : {}),
+          },
+        },
+      );
 
       return {
         content: [

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, spotifyApiRequest } from './utils.js';
 
 const getPlaylist: tool<{
   playlistId: z.ZodString;
@@ -21,7 +21,11 @@ const getPlaylist: tool<{
 
       const owner =
         playlist.owner?.display_name ?? playlist.owner?.id ?? 'Unknown';
-      const tracksTotal = playlist.tracks?.total ?? 0;
+      const playlistWithItems = playlist as typeof playlist & {
+        items?: { total?: number };
+      };
+      const tracksTotal =
+        playlistWithItems.items?.total ?? playlist.tracks?.total ?? 0;
       const isPublic = playlist.public ? 'Public' : 'Private';
       const isCollaborative = playlist.collaborative ? ' | Collaborative' : '';
       const description = playlist.description
@@ -173,14 +177,17 @@ const removeTracksFromPlaylist: tool<{
     const { playlistId, trackIds, snapshotId } = args;
 
     try {
-      const tracks = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
-
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.removeItemsFromPlaylist(playlistId, {
-          tracks,
-          ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
-      });
+      const items = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
+      await spotifyApiRequest<{ snapshot_id: string }>(
+        `/playlists/${playlistId}/items`,
+        {
+          method: 'DELETE',
+          body: {
+            items,
+            ...(snapshotId ? { snapshot_id: snapshotId } : {}),
+          },
+        },
+      );
 
       return {
         content: [
@@ -246,14 +253,18 @@ const reorderPlaylistItems: tool<{
       args;
 
     try {
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.updatePlaylistItems(playlistId, {
-          range_start: rangeStart,
-          insert_before: insertBefore,
-          ...(rangeLength !== undefined ? { range_length: rangeLength } : {}),
-          ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
-      });
+      await spotifyApiRequest<{ snapshot_id: string }>(
+        `/playlists/${playlistId}/items`,
+        {
+          method: 'PUT',
+          body: {
+            range_start: rangeStart,
+            insert_before: insertBefore,
+            ...(rangeLength !== undefined ? { range_length: rangeLength } : {}),
+            ...(snapshotId ? { snapshot_id: snapshotId } : {}),
+          },
+        },
+      );
 
       const count = rangeLength ?? 1;
       return {

--- a/src/read.ts
+++ b/src/read.ts
@@ -6,6 +6,7 @@ import {
   formatDuration,
   handleSpotifyRequest,
   loadSpotifyConfig,
+  spotifyApiRequest,
 } from './utils.js';
 
 function isTrack(item: any): item is SpotifyTrack {
@@ -277,14 +278,16 @@ const getPlaylistTracks: tool<{
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { playlistId, limit = 50, offset = 0 } = args;
 
-    const playlistTracks = await handleSpotifyRequest(async (spotifyApi) => {
-      return await spotifyApi.playlists.getPlaylistItems(
-        playlistId,
-        undefined,
-        undefined,
-        limit as MaxInt<50>,
+    const playlistTracks = await spotifyApiRequest<{
+      items: Array<{
+        item?: SpotifyTrack | null;
+      }>;
+      total: number;
+    }>(`/playlists/${playlistId}/items`, {
+      query: {
+        limit,
         offset,
-      );
+      },
     });
 
     if ((playlistTracks.items?.length ?? 0) === 0) {
@@ -300,7 +303,7 @@ const getPlaylistTracks: tool<{
 
     const formattedTracks = playlistTracks.items
       .map((item, i) => {
-        const { track } = item;
+        const track = item.item;
         if (!track) return `${offset + i + 1}. [Removed track]`;
 
         if (isTrack(track)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,60 @@ export async function createSpotifyApi(): Promise<SpotifyApi> {
   return cachedSpotifyApi;
 }
 
+export type SpotifyApiRequestOptions = {
+  method?: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+  headers?: Record<string, string>;
+};
+
+export async function spotifyApiRequest<T>(
+  path: string,
+  options: SpotifyApiRequestOptions = {},
+): Promise<T> {
+  await createSpotifyApi();
+  const config = loadSpotifyConfig();
+
+  if (!config.accessToken) {
+    throw new Error(
+      'Missing Spotify access token. Please run "npm run auth" to re-authenticate.',
+    );
+  }
+
+  const url = new URL(
+    path.startsWith('http') ? path : `https://api.spotify.com/v1${path}`,
+  );
+
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  const response = await fetch(url, {
+    method: options.method ?? (options.body === undefined ? 'GET' : 'POST'),
+    headers: {
+      Authorization: `Bearer ${config.accessToken}`,
+      ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      ...options.headers,
+    },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Spotify API ${response.status} ${response.statusText}: ${responseText}`,
+    );
+  }
+
+  if (responseText.length === 0) {
+    return undefined as T;
+  }
+
+  return JSON.parse(responseText) as T;
+}
+
 function generateRandomString(length: number): string {
   const array = new Uint8Array(length);
   crypto.getRandomValues(array);


### PR DESCRIPTION
## Summary
- replace the broken playlist item SDK calls with direct Spotify Web API `/items` requests for playlist track reads, adds, removes, and reorders
- add a small shared helper for authenticated direct Spotify API requests
- keep `getPlaylist` on the SDK, but read the track count from `items.total` when that is the shape Spotify returns

## Verification
- `npm run build`
- verified add/remove against playlist `2tKIXK9z5hAfQslC58UKHC` and restored the original track count from `16 -> 17 -> 16`