### PR TITLE
fix: migrate to Spotify February 2026 API changes

### DIFF
--- a/src/albums.ts
+++ b/src/albums.ts
@@ -203,16 +203,17 @@ const saveOrRemoveAlbumForUser: tool<{
 
     try {
       const config = loadSpotifyConfig();
-      const uris = albumIds.map((id) => `spotify:album:${id}`);
+      const uris = albumIds.map((id) => `spotify:album:${id}`).join(',');
 
-      const response = await fetch('https://api.spotify.com/v1/me/library', {
-        method: action === 'save' ? 'PUT' : 'DELETE',
-        headers: {
-          Authorization: `Bearer ${config.accessToken}`,
-          'Content-Type': 'application/json',
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/library?uris=${encodeURIComponent(uris)}`,
+        {
+          method: action === 'save' ? 'PUT' : 'DELETE',
+          headers: {
+            Authorization: `Bearer ${config.accessToken}`,
+          },
         },
-        body: JSON.stringify({ uris }),
-      });
+      );
 
       if (!response.ok) {
         const errorData = await response.text();

--- a/src/albums.ts
+++ b/src/albums.ts
@@ -1,7 +1,7 @@
 import type { MaxInt } from '@spotify/web-api-ts-sdk';
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { formatDuration, handleSpotifyRequest, loadSpotifyConfig } from './utils.js';
+import { formatDuration, getValidConfig, handleSpotifyRequest } from './utils.js';
 
 const getAlbums: tool<{
   albumIds: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString>]>;
@@ -202,7 +202,7 @@ const saveOrRemoveAlbumForUser: tool<{
     }
 
     try {
-      const config = loadSpotifyConfig();
+      const config = await getValidConfig();
       const uris = albumIds.map((id) => `spotify:album:${id}`).join(',');
 
       const response = await fetch(
@@ -272,7 +272,7 @@ const checkUsersSavedAlbums: tool<{
     }
 
     try {
-      const config = loadSpotifyConfig();
+      const config = await getValidConfig();
       const uris = albumIds.map((id) => `spotify:album:${id}`);
       const params = new URLSearchParams({ uris: uris.join(',') });
 

--- a/src/albums.ts
+++ b/src/albums.ts
@@ -1,7 +1,7 @@
 import type { MaxInt } from '@spotify/web-api-ts-sdk';
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { formatDuration, handleSpotifyRequest } from './utils.js';
+import { formatDuration, handleSpotifyRequest, loadSpotifyConfig } from './utils.js';
 
 const getAlbums: tool<{
   albumIds: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString>]>;
@@ -31,9 +31,7 @@ const getAlbums: tool<{
 
     try {
       const albums = await handleSpotifyRequest(async (spotifyApi) => {
-        return ids.length === 1
-          ? [await spotifyApi.albums.get(ids[0])]
-          : await spotifyApi.albums.get(ids);
+        return await Promise.all(ids.map((id) => spotifyApi.albums.get(id)));
       });
 
       if (albums.length === 0) {
@@ -204,11 +202,22 @@ const saveOrRemoveAlbumForUser: tool<{
     }
 
     try {
-      await handleSpotifyRequest(async (spotifyApi) => {
-        return action === 'save'
-          ? await spotifyApi.currentUser.albums.saveAlbums(albumIds)
-          : await spotifyApi.currentUser.albums.removeSavedAlbums(albumIds);
+      const config = loadSpotifyConfig();
+      const uris = albumIds.map((id) => `spotify:album:${id}`);
+
+      const response = await fetch('https://api.spotify.com/v1/me/library', {
+        method: action === 'save' ? 'PUT' : 'DELETE',
+        headers: {
+          Authorization: `Bearer ${config.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ uris }),
       });
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to ${action} albums: ${errorData}`);
+      }
 
       const actionPastTense = action === 'save' ? 'saved' : 'removed';
       const preposition = action === 'save' ? 'to' : 'from';
@@ -262,9 +271,23 @@ const checkUsersSavedAlbums: tool<{
     }
 
     try {
-      const savedStatus = await handleSpotifyRequest(async (spotifyApi) => {
-        return await spotifyApi.currentUser.albums.hasSavedAlbums(albumIds);
-      });
+      const config = loadSpotifyConfig();
+      const uris = albumIds.map((id) => `spotify:album:${id}`);
+      const params = new URLSearchParams({ uris: uris.join(',') });
+
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/library/contains?${params}`,
+        {
+          headers: { Authorization: `Bearer ${config.accessToken}` },
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to check saved albums: ${errorData}`);
+      }
+
+      const savedStatus: boolean[] = await response.json();
 
       const formattedResults = albumIds
         .map((albumId, i) => {

--- a/src/play.ts
+++ b/src/play.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest, loadSpotifyConfig } from './utils.js';
+import { getValidConfig, handleSpotifyRequest } from './utils.js';
 
 const playMusic: tool<{
   uri: z.ZodOptional<z.ZodString>;
@@ -206,7 +206,7 @@ const createPlaylist: tool<{
       };
     }
 
-    const config = loadSpotifyConfig();
+    const config = await getValidConfig();
     const response = await fetch('https://api.spotify.com/v1/me/playlists', {
       method: 'POST',
       headers: {
@@ -271,7 +271,7 @@ const addTracksToPlaylist: tool<{
 
     try {
       const trackUris = trackIds.map((id) => `spotify:track:${id}`);
-      const config = loadSpotifyConfig();
+      const config = await getValidConfig();
 
       const response = await fetch(
         `https://api.spotify.com/v1/playlists/${playlistId}/items`,

--- a/src/play.ts
+++ b/src/play.ts
@@ -545,6 +545,98 @@ const adjustVolume: tool<{
   },
 };
 
+const seekToPosition: tool<{
+  positionMs: z.ZodNumber;
+  deviceId: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'seekToPosition',
+  description: 'Seek to a position in the currently playing track',
+  schema: {
+    positionMs: z.number().nonnegative().describe('Position in milliseconds to seek to'),
+    deviceId: z.string().optional().describe('Device ID to target (optional)'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { positionMs, deviceId } = args;
+    try {
+      await handleSpotifyRequest(async (spotifyApi) => {
+        await spotifyApi.player.seekToPosition(positionMs, deviceId);
+      });
+      return { content: [{ type: 'text', text: `Seeked to ${Math.floor(positionMs / 1000)}s` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error seeking: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const setRepeatMode: tool<{
+  state: z.ZodEnum<['track', 'context', 'off']>;
+  deviceId: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'setRepeatMode',
+  description: "Set repeat mode: 'track' repeats the current track, 'context' repeats the current album/playlist, 'off' disables repeat",
+  schema: {
+    state: z.enum(['track', 'context', 'off']).describe("Repeat mode: 'track', 'context', or 'off'"),
+    deviceId: z.string().optional().describe('Device ID to target (optional)'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { state, deviceId } = args;
+    try {
+      await handleSpotifyRequest(async (spotifyApi) => {
+        await spotifyApi.player.setRepeatMode(state, deviceId);
+      });
+      return { content: [{ type: 'text', text: `Repeat mode set to: ${state}` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error setting repeat mode: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const toggleShuffle: tool<{
+  state: z.ZodBoolean;
+  deviceId: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'toggleShuffle',
+  description: 'Toggle shuffle mode on or off',
+  schema: {
+    state: z.boolean().describe('true to enable shuffle, false to disable'),
+    deviceId: z.string().optional().describe('Device ID to target (optional)'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { state, deviceId } = args;
+    try {
+      await handleSpotifyRequest(async (spotifyApi) => {
+        await spotifyApi.player.togglePlaybackShuffle(state, deviceId);
+      });
+      return { content: [{ type: 'text', text: `Shuffle ${state ? 'enabled' : 'disabled'}` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error toggling shuffle: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const transferPlayback: tool<{
+  deviceId: z.ZodString;
+  play: z.ZodOptional<z.ZodBoolean>;
+}> = {
+  name: 'transferPlayback',
+  description: 'Transfer playback to a different device',
+  schema: {
+    deviceId: z.string().describe('The ID of the device to transfer playback to'),
+    play: z.boolean().optional().describe('Whether to ensure playback starts on the new device (default: keep current state)'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { deviceId, play } = args;
+    try {
+      await handleSpotifyRequest(async (spotifyApi) => {
+        await spotifyApi.player.transferPlayback([deviceId], play);
+      });
+      return { content: [{ type: 'text', text: `Playback transferred to device: ${deviceId}` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error transferring playback: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
 export const playTools = [
   playMusic,
   pausePlayback,
@@ -556,4 +648,8 @@ export const playTools = [
   addToQueue,
   setVolume,
   adjustVolume,
+  seekToPosition,
+  setRepeatMode,
+  toggleShuffle,
+  transferPlayback,
 ];

--- a/src/play.ts
+++ b/src/play.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, loadSpotifyConfig } from './utils.js';
 
 const playMusic: tool<{
   uri: z.ZodOptional<z.ZodString>;
@@ -165,9 +165,11 @@ const createPlaylist: tool<{
   name: z.ZodString;
   description: z.ZodOptional<z.ZodString>;
   public: z.ZodOptional<z.ZodBoolean>;
+  collaborative: z.ZodOptional<z.ZodBoolean>;
 }> = {
   name: 'createPlaylist',
-  description: 'Create a new playlist on Spotify',
+  description:
+    'Create a new playlist on Spotify. Defaults to private (public: false). A playlist cannot be both public and collaborative at the same time.',
   schema: {
     name: z.string().describe('The name of the playlist'),
     description: z
@@ -177,20 +179,54 @@ const createPlaylist: tool<{
     public: z
       .boolean()
       .optional()
-      .describe('Whether the playlist should be public'),
+      .describe('Whether the playlist should be public (default: false)'),
+    collaborative: z
+      .boolean()
+      .optional()
+      .describe(
+        'Whether the playlist should be collaborative — anyone with the link can add/remove tracks. Requires public to be false.',
+      ),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
-    const { name, description, public: isPublic = false } = args;
+    const {
+      name,
+      description,
+      public: isPublic = false,
+      collaborative = false,
+    } = args;
 
-    const result = await handleSpotifyRequest(async (spotifyApi) => {
-      const me = await spotifyApi.currentUser.profile();
+    if (collaborative && isPublic) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: 'Error: A playlist cannot be both collaborative and public at the same time.',
+          },
+        ],
+      };
+    }
 
-      return await spotifyApi.playlists.createPlaylist(me.id, {
+    const config = loadSpotifyConfig();
+    const response = await fetch('https://api.spotify.com/v1/me/playlists', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
         name,
         description,
         public: isPublic,
-      });
+        collaborative,
+      }),
     });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      throw new Error(`Failed to create playlist: ${errorData}`);
+    }
+
+    const result = await response.json();
 
     return {
       content: [
@@ -235,14 +271,27 @@ const addTracksToPlaylist: tool<{
 
     try {
       const trackUris = trackIds.map((id) => `spotify:track:${id}`);
+      const config = loadSpotifyConfig();
 
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.addItemsToPlaylist(
-          playlistId,
-          trackUris,
-          position,
-        );
-      });
+      const response = await fetch(
+        `https://api.spotify.com/v1/playlists/${playlistId}/items`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${config.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            uris: trackUris,
+            ...(position !== undefined ? { position } : {}),
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to add tracks: ${errorData}`);
+      }
 
       return {
         content: [

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -21,7 +21,7 @@ const getPlaylist: tool<{
 
       const owner =
         playlist.owner?.display_name ?? playlist.owner?.id ?? 'Unknown';
-      const tracksTotal = playlist.tracks?.total ?? 0;
+      const tracksTotal = (playlist as any).items?.total ?? 0;
       const isPublic = playlist.public ? 'Public' : 'Private';
       const isCollaborative = playlist.collaborative ? ' | Collaborative' : '';
       const description = playlist.description

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, loadSpotifyConfig } from './utils.js';
 
 const getPlaylist: tool<{
   playlistId: z.ZodString;
@@ -68,7 +68,7 @@ const updatePlaylist: tool<{
 }> = {
   name: 'updatePlaylist',
   description:
-    'Update the details of a Spotify playlist (name, description, public/private, collaborative)',
+    'Update the details of a Spotify playlist (name, description, public/private, collaborative). A playlist cannot be both public and collaborative at the same time.',
   schema: {
     playlistId: z.string().describe('The Spotify ID of the playlist'),
     name: z.string().optional().describe('New name for the playlist'),
@@ -107,6 +107,17 @@ const updatePlaylist: tool<{
           {
             type: 'text',
             text: 'Error: At least one field to update must be provided (name, description, public, collaborative)',
+          },
+        ],
+      };
+    }
+
+    if (collaborative && isPublic) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: 'Error: A playlist cannot be both collaborative and public at the same time.',
           },
         ],
       };
@@ -174,13 +185,27 @@ const removeTracksFromPlaylist: tool<{
 
     try {
       const tracks = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
+      const config = loadSpotifyConfig();
 
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.removeItemsFromPlaylist(playlistId, {
-          tracks,
-          ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
-      });
+      const response = await fetch(
+        `https://api.spotify.com/v1/playlists/${playlistId}/items`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${config.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            tracks,
+            ...(snapshotId ? { snapshot_id: snapshotId } : {}),
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to remove tracks: ${errorData}`);
+      }
 
       return {
         content: [
@@ -246,14 +271,29 @@ const reorderPlaylistItems: tool<{
       args;
 
     try {
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.updatePlaylistItems(playlistId, {
-          range_start: rangeStart,
-          insert_before: insertBefore,
-          ...(rangeLength !== undefined ? { range_length: rangeLength } : {}),
-          ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
-      });
+      const config = loadSpotifyConfig();
+
+      const response = await fetch(
+        `https://api.spotify.com/v1/playlists/${playlistId}/items`,
+        {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${config.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            range_start: rangeStart,
+            insert_before: insertBefore,
+            ...(rangeLength !== undefined ? { range_length: rangeLength } : {}),
+            ...(snapshotId ? { snapshot_id: snapshotId } : {}),
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to reorder playlist items: ${errorData}`);
+      }
 
       const count = rangeLength ?? 1;
       return {

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest, loadSpotifyConfig } from './utils.js';
+import { getValidConfig, handleSpotifyRequest } from './utils.js';
 
 const getPlaylist: tool<{
   playlistId: z.ZodString;
@@ -185,7 +185,7 @@ const removeTracksFromPlaylist: tool<{
 
     try {
       const tracks = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
-      const config = loadSpotifyConfig();
+      const config = await getValidConfig();
 
       const response = await fetch(
         `https://api.spotify.com/v1/playlists/${playlistId}/items`,
@@ -271,7 +271,7 @@ const reorderPlaylistItems: tool<{
       args;
 
     try {
-      const config = loadSpotifyConfig();
+      const config = await getValidConfig();
 
       const response = await fetch(
         `https://api.spotify.com/v1/playlists/${playlistId}/items`,

--- a/src/read.ts
+++ b/src/read.ts
@@ -235,7 +235,7 @@ const getMyPlaylists: tool<{
 
     const formattedPlaylists = playlists.items
       .map((playlist, i) => {
-        const tracksTotal = playlist.tracks?.total ? playlist.tracks.total : 0;
+        const tracksTotal = (playlist as any).items?.total ?? 0;
         return `${i + 1}. "${playlist.name}" (${tracksTotal} tracks) - ID: ${
           playlist.id
         }`;

--- a/src/read.ts
+++ b/src/read.ts
@@ -1002,6 +1002,255 @@ const getSavedShows: tool<{
   },
 };
 
+const getArtist: tool<{ artistId: z.ZodString }> = {
+  name: 'getArtist',
+  description: 'Get metadata for a single Spotify artist',
+  schema: { artistId: z.string().describe('The Spotify ID of the artist') },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    try {
+      const config = await getValidConfig();
+      const response = await fetch(`https://api.spotify.com/v1/artists/${args.artistId}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const a = await response.json();
+      const genres = a.genres?.join(', ') || 'N/A';
+      return {
+        content: [{
+          type: 'text',
+          text: `# ${a.name}\n\n**Genres**: ${genres}\n**ID**: ${a.id}\n**URI**: ${a.uri}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting artist: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getArtistAlbums: tool<{
+  artistId: z.ZodString;
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getArtistAlbums',
+  description: "Get albums released by a Spotify artist",
+  schema: {
+    artistId: z.string().describe('The Spotify ID of the artist'),
+    limit: z.number().min(1).max(50).optional().describe('Maximum number of albums to return (1-50)'),
+    offset: z.number().min(0).optional().describe('Offset for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { artistId, limit = 20, offset = 0 } = args;
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+      const response = await fetch(`https://api.spotify.com/v1/artists/${artistId}/albums?${params}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const data = await response.json();
+      if (data.items.length === 0) return { content: [{ type: 'text', text: 'No albums found for this artist' }] };
+      const formatted = data.items
+        .map((a: any, i: number) => `${offset + i + 1}. "${a.name}" (${a.album_type}, ${a.release_date}) - ID: ${a.id}`)
+        .join('\n');
+      return { content: [{ type: 'text', text: `# Albums by Artist (${offset + 1}-${offset + data.items.length} of ${data.total})\n\n${formatted}` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting artist albums: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getTrack: tool<{ trackId: z.ZodString }> = {
+  name: 'getTrack',
+  description: 'Get metadata for a single Spotify track',
+  schema: { trackId: z.string().describe('The Spotify ID of the track') },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    try {
+      const config = await getValidConfig();
+      const response = await fetch(`https://api.spotify.com/v1/tracks/${args.trackId}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const t = await response.json();
+      const artists = t.artists.map((a: any) => a.name).join(', ');
+      const duration = formatDuration(t.duration_ms);
+      return {
+        content: [{
+          type: 'text',
+          text: `# "${t.name}"\n\n**Artists**: ${artists}\n**Album**: ${t.album?.name}\n**Duration**: ${duration}\n**ID**: ${t.id}\n**URI**: ${t.uri}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting track: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getShow: tool<{ showId: z.ZodString }> = {
+  name: 'getShow',
+  description: 'Get metadata for a single Spotify podcast show',
+  schema: { showId: z.string().describe('The Spotify ID of the show') },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    try {
+      const config = await getValidConfig();
+      const response = await fetch(`https://api.spotify.com/v1/shows/${args.showId}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const s = await response.json();
+      return {
+        content: [{
+          type: 'text',
+          text: `# "${s.name}"\n\n**Total Episodes**: ${s.total_episodes}\n**ID**: ${s.id}\n**URI**: ${s.uri}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting show: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getShowEpisodes: tool<{
+  showId: z.ZodString;
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getShowEpisodes',
+  description: 'Get episodes belonging to a Spotify podcast show',
+  schema: {
+    showId: z.string().describe('The Spotify ID of the show'),
+    limit: z.number().min(1).max(50).optional().describe('Maximum number of episodes to return (1-50)'),
+    offset: z.number().min(0).optional().describe('Offset for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { showId, limit = 20, offset = 0 } = args;
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+      const response = await fetch(`https://api.spotify.com/v1/shows/${showId}/episodes?${params}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const data = await response.json();
+      if (data.items.length === 0) return { content: [{ type: 'text', text: 'No episodes found' }] };
+      const formatted = data.items
+        .map((ep: any, i: number) => `${offset + i + 1}. "${ep.name}" (${formatDuration(ep.duration_ms)}) - ID: ${ep.id}`)
+        .join('\n');
+      return { content: [{ type: 'text', text: `# Episodes (${offset + 1}-${offset + data.items.length} of ${data.total})\n\n${formatted}` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting show episodes: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getEpisode: tool<{ episodeId: z.ZodString }> = {
+  name: 'getEpisode',
+  description: 'Get metadata for a single Spotify podcast episode',
+  schema: { episodeId: z.string().describe('The Spotify ID of the episode') },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    try {
+      const config = await getValidConfig();
+      const response = await fetch(`https://api.spotify.com/v1/episodes/${args.episodeId}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const ep = await response.json();
+      const duration = formatDuration(ep.duration_ms);
+      return {
+        content: [{
+          type: 'text',
+          text: `# "${ep.name}"\n\n**Show**: ${ep.show?.name}\n**Duration**: ${duration}\n**Release Date**: ${ep.release_date}\n**ID**: ${ep.id}\n**URI**: ${ep.uri}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting episode: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getAudiobook: tool<{ audiobookId: z.ZodString }> = {
+  name: 'getAudiobook',
+  description: 'Get metadata for a single Spotify audiobook',
+  schema: { audiobookId: z.string().describe('The Spotify ID of the audiobook') },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    try {
+      const config = await getValidConfig();
+      const response = await fetch(`https://api.spotify.com/v1/audiobooks/${args.audiobookId}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const b = await response.json();
+      const authors = b.authors?.map((a: any) => a.name).join(', ') || 'Unknown';
+      return {
+        content: [{
+          type: 'text',
+          text: `# "${b.name}"\n\n**Authors**: ${authors}\n**Total Chapters**: ${b.total_chapters}\n**ID**: ${b.id}\n**URI**: ${b.uri}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting audiobook: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getAudiobookChapters: tool<{
+  audiobookId: z.ZodString;
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getAudiobookChapters',
+  description: 'Get chapters belonging to a Spotify audiobook',
+  schema: {
+    audiobookId: z.string().describe('The Spotify ID of the audiobook'),
+    limit: z.number().min(1).max(50).optional().describe('Maximum number of chapters to return (1-50)'),
+    offset: z.number().min(0).optional().describe('Offset for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { audiobookId, limit = 20, offset = 0 } = args;
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+      const response = await fetch(`https://api.spotify.com/v1/audiobooks/${audiobookId}/chapters?${params}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const data = await response.json();
+      if (data.items.length === 0) return { content: [{ type: 'text', text: 'No chapters found' }] };
+      const formatted = data.items
+        .map((ch: any, i: number) => `${offset + i + 1}. "${ch.name}" (${formatDuration(ch.duration_ms)}) - ID: ${ch.id}`)
+        .join('\n');
+      return { content: [{ type: 'text', text: `# Chapters (${offset + 1}-${offset + data.items.length} of ${data.total})\n\n${formatted}` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting audiobook chapters: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
+const getChapter: tool<{ chapterId: z.ZodString }> = {
+  name: 'getChapter',
+  description: 'Get metadata for a single Spotify audiobook chapter',
+  schema: { chapterId: z.string().describe('The Spotify ID of the chapter') },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    try {
+      const config = await getValidConfig();
+      const response = await fetch(`https://api.spotify.com/v1/chapters/${args.chapterId}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const ch = await response.json();
+      const duration = formatDuration(ch.duration_ms);
+      return {
+        content: [{
+          type: 'text',
+          text: `# "${ch.name}"\n\n**Audiobook**: ${ch.audiobook?.name}\n**Duration**: ${duration}\n**Chapter**: ${ch.chapter_number}\n**ID**: ${ch.id}\n**URI**: ${ch.uri}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting chapter: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
 export const readTools = [
   searchSpotify,
   getNowPlaying,
@@ -1015,6 +1264,15 @@ export const readTools = [
   getSavedAudiobooks,
   getSavedEpisodes,
   getSavedShows,
+  getArtist,
+  getArtistAlbums,
+  getTrack,
+  getShow,
+  getShowEpisodes,
+  getEpisode,
+  getAudiobook,
+  getAudiobookChapters,
+  getChapter,
   getQueue,
   getAvailableDevices,
 ];

--- a/src/read.ts
+++ b/src/read.ts
@@ -276,15 +276,23 @@ const getPlaylistTracks: tool<{
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { playlistId, limit = 50, offset = 0 } = args;
 
-    const playlistTracks = await handleSpotifyRequest(async (spotifyApi) => {
-      return await spotifyApi.playlists.getPlaylistItems(
-        playlistId,
-        undefined,
-        undefined,
-        limit as MaxInt<50>,
-        offset,
-      );
+    const config = await getValidConfig();
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
     });
+
+    const response = await fetch(
+      `https://api.spotify.com/v1/playlists/${playlistId}/items?${params}`,
+      { headers: { Authorization: `Bearer ${config.accessToken}` } },
+    );
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      throw new Error(`Failed to get playlist tracks: ${errorData}`);
+    }
+
+    const playlistTracks = await response.json();
 
     if ((playlistTracks.items?.length ?? 0) === 0) {
       return {
@@ -298,12 +306,12 @@ const getPlaylistTracks: tool<{
     }
 
     const formattedTracks = playlistTracks.items
-      .map((item, i) => {
-        const { track } = item;
+      .map((item: any, i: number) => {
+        const track = item.item ?? item.track;
         if (!track) return `${offset + i + 1}. [Removed track]`;
 
         if (isTrack(track)) {
-          const artists = track.artists.map((a) => a.name).join(', ');
+          const artists = track.artists.map((a: any) => a.name).join(', ');
           const duration = formatDuration(track.duration_ms);
           return `${offset + i + 1}. "${track.name}" by ${artists} (${duration}) - ID: ${track.id}`;
         }

--- a/src/read.ts
+++ b/src/read.ts
@@ -1002,6 +1002,30 @@ const getSavedShows: tool<{
   },
 };
 
+const getCurrentUserProfile: tool<Record<string, never>> = {
+  name: 'getCurrentUserProfile',
+  description: 'Get profile information for the current authenticated Spotify user',
+  schema: {},
+  handler: async (_args, _extra: SpotifyHandlerExtra) => {
+    try {
+      const config = await getValidConfig();
+      const response = await fetch('https://api.spotify.com/v1/me', {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const u = await response.json();
+      return {
+        content: [{
+          type: 'text',
+          text: `# ${u.display_name ?? u.id}\n\n**ID**: ${u.id}\n**URI**: ${u.uri}\n**Profile URL**: ${u.external_urls?.spotify ?? 'N/A'}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting profile: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
 const getArtist: tool<{ artistId: z.ZodString }> = {
   name: 'getArtist',
   description: 'Get metadata for a single Spotify artist',
@@ -1264,6 +1288,7 @@ export const readTools = [
   getSavedAudiobooks,
   getSavedEpisodes,
   getSavedShows,
+  getCurrentUserProfile,
   getArtist,
   getArtistAlbums,
   getTrack,

--- a/src/read.ts
+++ b/src/read.ts
@@ -34,13 +34,13 @@ const searchSpotify: tool<{
     limit: z
       .number()
       .min(1)
-      .max(50)
+      .max(10)
       .optional()
-      .describe('Maximum number of results to return (10-50)'),
+      .describe('Maximum number of results to return (1-10)'),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { query, type, limit } = args;
-    const limitValue = limit ?? 10;
+    const limitValue = Math.min(limit ?? 10, 10);
 
     try {
       const results = await handleSpotifyRequest(async (spotifyApi) => {

--- a/src/read.ts
+++ b/src/read.ts
@@ -627,16 +627,17 @@ const saveUsersTracks: tool<{
 
     try {
       const config = loadSpotifyConfig();
-      const uris = trackIds.map((id) => `spotify:track:${id}`);
+      const uris = trackIds.map((id) => `spotify:track:${id}`).join(',');
 
-      const response = await fetch('https://api.spotify.com/v1/me/library', {
-        method: 'PUT',
-        headers: {
-          Authorization: `Bearer ${config.accessToken}`,
-          'Content-Type': 'application/json',
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/library?uris=${encodeURIComponent(uris)}`,
+        {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${config.accessToken}`,
+          },
         },
-        body: JSON.stringify({ uris }),
-      });
+      );
 
       if (!response.ok) {
         const errorData = await response.text();

--- a/src/read.ts
+++ b/src/read.ts
@@ -737,6 +737,271 @@ const removeUsersSavedTracks: tool<{
   },
 };
 
+const getFollowedArtists: tool<{
+  limit: z.ZodOptional<z.ZodNumber>;
+  after: z.ZodOptional<z.ZodString>;
+}> = {
+  name: 'getFollowedArtists',
+  description: "Get artists followed by the current user",
+  schema: {
+    limit: z
+      .number()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe('Maximum number of artists to return (1-50)'),
+    after: z
+      .string()
+      .optional()
+      .describe('The last artist ID from a previous request for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { limit = 50, after } = args;
+
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ type: 'artist', limit: String(limit) });
+      if (after) params.set('after', after);
+
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/following?${params}`,
+        { headers: { Authorization: `Bearer ${config.accessToken}` } },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to get followed artists: ${errorData}`);
+      }
+
+      const data = await response.json();
+      const artists = data.artists;
+
+      if (artists.items.length === 0) {
+        return {
+          content: [{ type: 'text', text: "You aren't following any artists" }],
+        };
+      }
+
+      const formatted = artists.items
+        .map((a: any, i: number) => `${i + 1}. ${a.name} - ID: ${a.id}`)
+        .join('\n');
+
+      const nextCursor = artists.cursors?.after
+        ? `\n\nNext page cursor: ${artists.cursors.after}`
+        : '';
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `# Followed Artists (${artists.items.length} of ${artists.total})\n\n${formatted}${nextCursor}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error getting followed artists: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+  },
+};
+
+const getSavedAudiobooks: tool<{
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getSavedAudiobooks',
+  description: "Get audiobooks saved in the current user's library",
+  schema: {
+    limit: z.number().min(1).max(50).optional().describe('Maximum number of audiobooks to return (1-50)'),
+    offset: z.number().min(0).optional().describe('Offset for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { limit = 20, offset = 0 } = args;
+
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/audiobooks?${params}`,
+        { headers: { Authorization: `Bearer ${config.accessToken}` } },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to get saved audiobooks: ${errorData}`);
+      }
+
+      const data = await response.json();
+
+      if (data.items.length === 0) {
+        return {
+          content: [{ type: 'text', text: "You don't have any saved audiobooks" }],
+        };
+      }
+
+      const formatted = data.items
+        .map((item: any, i: number) => {
+          const b = item.audiobook ?? item;
+          const authors = b.authors?.map((a: any) => a.name).join(', ') ?? 'Unknown';
+          return `${offset + i + 1}. "${b.name}" by ${authors} - ID: ${b.id}`;
+        })
+        .join('\n');
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `# Saved Audiobooks (${offset + 1}-${offset + data.items.length} of ${data.total})\n\n${formatted}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error getting saved audiobooks: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+  },
+};
+
+const getSavedEpisodes: tool<{
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getSavedEpisodes',
+  description: "Get podcast episodes saved in the current user's library",
+  schema: {
+    limit: z.number().min(1).max(50).optional().describe('Maximum number of episodes to return (1-50)'),
+    offset: z.number().min(0).optional().describe('Offset for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { limit = 20, offset = 0 } = args;
+
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/episodes?${params}`,
+        { headers: { Authorization: `Bearer ${config.accessToken}` } },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to get saved episodes: ${errorData}`);
+      }
+
+      const data = await response.json();
+
+      if (data.items.length === 0) {
+        return {
+          content: [{ type: 'text', text: "You don't have any saved episodes" }],
+        };
+      }
+
+      const formatted = data.items
+        .map((item: any, i: number) => {
+          const ep = item.episode ?? item;
+          const duration = formatDuration(ep.duration_ms);
+          return `${offset + i + 1}. "${ep.name}" (${duration}) - ID: ${ep.id}`;
+        })
+        .join('\n');
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `# Saved Episodes (${offset + 1}-${offset + data.items.length} of ${data.total})\n\n${formatted}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error getting saved episodes: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+  },
+};
+
+const getSavedShows: tool<{
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getSavedShows',
+  description: "Get podcast shows saved in the current user's library",
+  schema: {
+    limit: z.number().min(1).max(50).optional().describe('Maximum number of shows to return (1-50)'),
+    offset: z.number().min(0).optional().describe('Offset for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { limit = 20, offset = 0 } = args;
+
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/shows?${params}`,
+        { headers: { Authorization: `Bearer ${config.accessToken}` } },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to get saved shows: ${errorData}`);
+      }
+
+      const data = await response.json();
+
+      if (data.items.length === 0) {
+        return {
+          content: [{ type: 'text', text: "You don't have any saved shows" }],
+        };
+      }
+
+      const formatted = data.items
+        .map((item: any, i: number) => {
+          const show = item.show ?? item;
+          return `${offset + i + 1}. "${show.name}" - ${show.total_episodes} episodes - ID: ${show.id}`;
+        })
+        .join('\n');
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `# Saved Shows (${offset + 1}-${offset + data.items.length} of ${data.total})\n\n${formatted}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error getting saved shows: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+  },
+};
+
 export const readTools = [
   searchSpotify,
   getNowPlaying,
@@ -746,6 +1011,10 @@ export const readTools = [
   getUsersSavedTracks,
   saveUsersTracks,
   removeUsersSavedTracks,
+  getFollowedArtists,
+  getSavedAudiobooks,
+  getSavedEpisodes,
+  getSavedShows,
   getQueue,
   getAvailableDevices,
 ];

--- a/src/read.ts
+++ b/src/read.ts
@@ -2,10 +2,9 @@ import type { MaxInt } from '@spotify/web-api-ts-sdk';
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, SpotifyTrack, tool } from './types.js';
 import {
-  createSpotifyApi,
   formatDuration,
+  getValidConfig,
   handleSpotifyRequest,
-  loadSpotifyConfig,
 } from './utils.js';
 
 function isTrack(item: any): item is SpotifyTrack {
@@ -626,7 +625,7 @@ const saveUsersTracks: tool<{
     }
 
     try {
-      const config = loadSpotifyConfig();
+      const config = await getValidConfig();
       const uris = trackIds.map((id) => `spotify:track:${id}`).join(',');
 
       const response = await fetch(
@@ -689,9 +688,7 @@ const removeUsersSavedTracks: tool<{
     }
 
     try {
-      // Ensure token is fresh (handles auto-refresh if needed)
-      await createSpotifyApi();
-      const config = loadSpotifyConfig();
+      const config = await getValidConfig();
 
       const uris = trackIds.map((id) => `spotify:track:${id}`).join(',');
       const response = await fetch(

--- a/src/read.ts
+++ b/src/read.ts
@@ -737,6 +737,37 @@ const removeUsersSavedTracks: tool<{
   },
 };
 
+const followArtists: tool<{
+  artistIds: z.ZodArray<z.ZodString>;
+  action: z.ZodEnum<['follow', 'unfollow']>;
+}> = {
+  name: 'followArtists',
+  description: 'Follow or unfollow one or more Spotify artists',
+  schema: {
+    artistIds: z.array(z.string()).min(1).describe('Array of Spotify artist IDs'),
+    action: z.enum(['follow', 'unfollow']).describe("'follow' to follow, 'unfollow' to unfollow"),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { artistIds, action } = args;
+    try {
+      const config = await getValidConfig();
+      const uris = artistIds.map((id) => `spotify:artist:${id}`).join(',');
+      const response = await fetch(
+        `https://api.spotify.com/v1/me/library?uris=${encodeURIComponent(uris)}`,
+        {
+          method: action === 'follow' ? 'PUT' : 'DELETE',
+          headers: { Authorization: `Bearer ${config.accessToken}` },
+        },
+      );
+      if (!response.ok) throw new Error(await response.text());
+      const verb = action === 'follow' ? 'Following' : 'Unfollowed';
+      return { content: [{ type: 'text', text: `${verb} ${artistIds.length} artist${artistIds.length === 1 ? '' : 's'}` }] };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error ${args.action}ing artists: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
 const getFollowedArtists: tool<{
   limit: z.ZodOptional<z.ZodNumber>;
   after: z.ZodOptional<z.ZodString>;
@@ -1332,6 +1363,7 @@ export const readTools = [
   getUsersSavedTracks,
   saveUsersTracks,
   removeUsersSavedTracks,
+  followArtists,
   getFollowedArtists,
   getSavedAudiobooks,
   getSavedEpisodes,

--- a/src/read.ts
+++ b/src/read.ts
@@ -1002,6 +1002,54 @@ const getSavedShows: tool<{
   },
 };
 
+const getUserTopItems: tool<{
+  type: z.ZodEnum<['artists', 'tracks']>;
+  timeRange: z.ZodOptional<z.ZodEnum<['short_term', 'medium_term', 'long_term']>>;
+  limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
+}> = {
+  name: 'getUserTopItems',
+  description: "Get the current user's top artists or tracks over a given time range",
+  schema: {
+    type: z.enum(['artists', 'tracks']).describe("Type of items to retrieve: 'artists' or 'tracks'"),
+    timeRange: z
+      .enum(['short_term', 'medium_term', 'long_term'])
+      .optional()
+      .describe("Time range: 'short_term' (~4 weeks), 'medium_term' (~6 months), 'long_term' (all time). Default: medium_term"),
+    limit: z.number().min(1).max(50).optional().describe('Maximum number of items to return (1-50)'),
+    offset: z.number().min(0).optional().describe('Offset for pagination'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { type, timeRange = 'medium_term', limit = 20, offset = 0 } = args;
+    try {
+      const config = await getValidConfig();
+      const params = new URLSearchParams({ time_range: timeRange, limit: String(limit), offset: String(offset) });
+      const response = await fetch(`https://api.spotify.com/v1/me/top/${type}?${params}`, {
+        headers: { Authorization: `Bearer ${config.accessToken}` },
+      });
+      if (!response.ok) throw new Error(await response.text());
+      const data = await response.json();
+      if (data.items.length === 0) return { content: [{ type: 'text', text: `No top ${type} found` }] };
+      const formatted = data.items
+        .map((item: any, i: number) => {
+          if (type === 'artists') return `${offset + i + 1}. ${item.name} - ID: ${item.id}`;
+          const artists = item.artists?.map((a: any) => a.name).join(', ');
+          return `${offset + i + 1}. "${item.name}" by ${artists} - ID: ${item.id}`;
+        })
+        .join('\n');
+      const rangeLabel: Record<string, string> = { short_term: '~4 weeks', medium_term: '~6 months', long_term: 'all time' };
+      return {
+        content: [{
+          type: 'text',
+          text: `# Your Top ${type === 'artists' ? 'Artists' : 'Tracks'} (${rangeLabel[timeRange]})\n\n${formatted}`,
+        }],
+      };
+    } catch (error) {
+      return { content: [{ type: 'text', text: `Error getting top ${type}: ${error instanceof Error ? error.message : String(error)}` }] };
+    }
+  },
+};
+
 const getCurrentUserProfile: tool<Record<string, never>> = {
   name: 'getCurrentUserProfile',
   description: 'Get profile information for the current authenticated Spotify user',
@@ -1288,6 +1336,7 @@ export const readTools = [
   getSavedAudiobooks,
   getSavedEpisodes,
   getSavedShows,
+  getUserTopItems,
   getCurrentUserProfile,
   getArtist,
   getArtistAlbums,

--- a/src/read.ts
+++ b/src/read.ts
@@ -605,6 +605,67 @@ const getAvailableDevices: tool<Record<string, never>> = {
   },
 };
 
+const saveUsersTracks: tool<{
+  trackIds: z.ZodArray<z.ZodString>;
+}> = {
+  name: 'saveUsersTracks',
+  description: 'Save (like) one or more tracks to the user\'s "Liked Songs" library (max 50 per request)',
+  schema: {
+    trackIds: z
+      .array(z.string())
+      .max(50)
+      .describe('Array of Spotify track IDs to save (max 50)'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { trackIds } = args;
+
+    if (trackIds.length === 0) {
+      return {
+        content: [{ type: 'text', text: 'Error: No track IDs provided' }],
+      };
+    }
+
+    try {
+      const config = loadSpotifyConfig();
+      const uris = trackIds.map((id) => `spotify:track:${id}`);
+
+      const response = await fetch('https://api.spotify.com/v1/me/library', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${config.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ uris }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new Error(`Failed to save tracks: ${errorData}`);
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Successfully saved ${trackIds.length} track${trackIds.length === 1 ? '' : 's'} to your Liked Songs`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error saving tracks to Liked Songs: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+      };
+    }
+  },
+};
+
 const removeUsersSavedTracks: tool<{
   trackIds: z.ZodArray<z.ZodString>;
 }> = {
@@ -677,6 +738,7 @@ export const readTools = [
   getPlaylistTracks,
   getRecentlyPlayed,
   getUsersSavedTracks,
+  saveUsersTracks,
   removeUsersSavedTracks,
   getQueue,
   getAvailableDevices,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,6 +209,7 @@ export async function authorizeSpotify(): Promise<void> {
     'user-library-modify',
     'user-follow-read',
     'user-follow-modify',
+    'user-top-read',
   ];
 
   const authParams = new URLSearchParams({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,15 +201,14 @@ export async function authorizeSpotify(): Promise<void> {
     'user-read-playback-state',
     'user-modify-playback-state',
     'user-read-currently-playing',
+    'user-read-recently-played',
     'playlist-read-private',
     'playlist-modify-private',
     'playlist-modify-public',
     'user-library-read',
     'user-library-modify',
-    'user-read-recently-played',
-    'user-modify-playback-state',
-    'user-read-playback-state',
-    'user-read-currently-playing',
+    'user-follow-read',
+    'user-follow-modify',
   ];
 
   const authParams = new URLSearchParams({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,24 +46,74 @@ export function saveSpotifyConfig(config: SpotifyConfig): void {
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), 'utf8');
 }
 
-export async function createSpotifyApi(): Promise<SpotifyApi> {
-  const config = loadSpotifyConfig();
-
-  if (config.accessToken && config.refreshToken) {
-    const accessToken = {
-      access_token: config.accessToken,
-      token_type: 'Bearer',
-      expires_in: Math.floor(
-        ((config.expiresAt ?? Date.now() + 3600000) - Date.now()) / 1000,
-      ),
-      refresh_token: config.refreshToken,
-    };
-    return SpotifyApi.withAccessToken(config.clientId, accessToken);
+async function refreshAccessToken(
+  config: SpotifyConfig,
+): Promise<{ access_token: string; expires_in: number }> {
+  if (!config.refreshToken) {
+    throw new Error('No refresh token available');
   }
 
-  throw new Error(
-    'No user tokens found. Please run "npm run auth" to authenticate.',
-  );
+  const tokenUrl = 'https://accounts.spotify.com/api/token';
+  const authHeader = `Basic ${base64Encode(`${config.clientId}:${config.clientSecret}`)}`;
+
+  const params = new URLSearchParams();
+  params.append('grant_type', 'refresh_token');
+  params.append('refresh_token', config.refreshToken);
+
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.text();
+    throw new Error(`Failed to refresh access token: ${errorData}`);
+  }
+
+  const data = await response.json();
+  return {
+    access_token: data.access_token,
+    expires_in: data.expires_in || 3600,
+  };
+}
+
+export async function getValidConfig(): Promise<SpotifyConfig> {
+  const config = loadSpotifyConfig();
+
+  if (!config.accessToken || !config.refreshToken) {
+    throw new Error(
+      'No user tokens found. Please run "npm run auth" to authenticate.',
+    );
+  }
+
+  const now = Date.now();
+  if (!config.expiresAt || config.expiresAt <= now) {
+    console.log('Access token expired, refreshing...');
+    const tokens = await refreshAccessToken(config);
+    config.accessToken = tokens.access_token;
+    config.expiresAt = now + tokens.expires_in * 1000;
+    saveSpotifyConfig(config);
+    console.log('Access token refreshed successfully');
+  }
+
+  return config;
+}
+
+export async function createSpotifyApi(): Promise<SpotifyApi> {
+  const config = await getValidConfig();
+
+  const now = Date.now();
+  const accessToken = {
+    access_token: config.accessToken!,
+    token_type: 'Bearer',
+    expires_in: Math.floor(((config.expiresAt ?? now + 3600000) - now) / 1000),
+    refresh_token: config.refreshToken!,
+  };
+  return SpotifyApi.withAccessToken(config.clientId, accessToken);
 }
 
 function generateRandomString(length: number): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,60 +46,24 @@ export function saveSpotifyConfig(config: SpotifyConfig): void {
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), 'utf8');
 }
 
-let cachedSpotifyApi: SpotifyApi | null = null;
-
 export async function createSpotifyApi(): Promise<SpotifyApi> {
   const config = loadSpotifyConfig();
 
   if (config.accessToken && config.refreshToken) {
-    const now = Date.now();
-    const shouldRefresh = !config.expiresAt || config.expiresAt <= now;
-
-    if (shouldRefresh) {
-      console.log(
-        'Access token expired or missing expiration time, refreshing...',
-      );
-      try {
-        const tokens = await refreshAccessToken(config);
-        config.accessToken = tokens.access_token;
-        config.expiresAt = now + tokens.expires_in * 1000; // Convert seconds to milliseconds
-        saveSpotifyConfig(config);
-        console.log('Access token refreshed successfully');
-
-        // Clear cached API instance to force recreation with new token
-        cachedSpotifyApi = null;
-      } catch (error) {
-        console.error('Failed to refresh token:', error);
-        throw new Error(
-          'Failed to refresh access token. Please run "npm run auth" to re-authenticate.',
-        );
-      }
-    }
-
-    if (cachedSpotifyApi) {
-      return cachedSpotifyApi;
-    }
-
     const accessToken = {
       access_token: config.accessToken,
       token_type: 'Bearer',
       expires_in: Math.floor(
-        ((config.expiresAt ?? now + 3600000) - now) / 1000,
+        ((config.expiresAt ?? Date.now() + 3600000) - Date.now()) / 1000,
       ),
       refresh_token: config.refreshToken,
     };
-
-    cachedSpotifyApi = SpotifyApi.withAccessToken(config.clientId, accessToken);
-    return cachedSpotifyApi;
+    return SpotifyApi.withAccessToken(config.clientId, accessToken);
   }
 
-  // Fallback to client credentials if no user tokens available
-  cachedSpotifyApi = SpotifyApi.withClientCredentials(
-    config.clientId,
-    config.clientSecret,
+  throw new Error(
+    'No user tokens found. Please run "npm run auth" to authenticate.',
   );
-
-  return cachedSpotifyApi;
 }
 
 function generateRandomString(length: number): string {
@@ -149,6 +113,7 @@ async function exchangeCodeForToken(
   }
 
   const data = await response.json();
+  console.log('Granted scopes:', data.scope);
   return {
     access_token: data.access_token,
     refresh_token: data.refresh_token,
@@ -156,40 +121,6 @@ async function exchangeCodeForToken(
   };
 }
 
-async function refreshAccessToken(
-  config: SpotifyConfig,
-): Promise<{ access_token: string; expires_in: number }> {
-  if (!config.refreshToken) {
-    throw new Error('No refresh token available');
-  }
-
-  const tokenUrl = 'https://accounts.spotify.com/api/token';
-  const authHeader = `Basic ${base64Encode(`${config.clientId}:${config.clientSecret}`)}`;
-
-  const params = new URLSearchParams();
-  params.append('grant_type', 'refresh_token');
-  params.append('refresh_token', config.refreshToken);
-
-  const response = await fetch(tokenUrl, {
-    method: 'POST',
-    headers: {
-      Authorization: authHeader,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: params,
-  });
-
-  if (!response.ok) {
-    const errorData = await response.text();
-    throw new Error(`Failed to refresh access token: ${errorData}`);
-  }
-
-  const data = await response.json();
-  return {
-    access_token: data.access_token,
-    expires_in: data.expires_in || 3600,
-  };
-}
 
 export async function authorizeSpotify(): Promise<void> {
   const config = loadSpotifyConfig();


### PR DESCRIPTION
## Summary

Spotify's [February 2026 API changes](https://developer.spotify.com/blog) removed several endpoints and renamed others. This PR migrates the MCP server to the new endpoints, fixes broken SDK calls, adds missing tools, and fills out the full available API surface.

## Endpoint migrations

- **`createPlaylist`**: `POST /users/{id}/playlists` → `POST /me/playlists`
- **`addTracksToPlaylist`**: `POST /playlists/{id}/tracks` → `POST /playlists/{id}/items`
- **`removeTracksFromPlaylist`**: `DELETE /playlists/{id}/tracks` → `DELETE /playlists/{id}/items`
- **`reorderPlaylistItems`**: `PUT /playlists/{id}/tracks` → `PUT /playlists/{id}/items`
- **`getPlaylistTracks`**: `GET /playlists/{id}/tracks` → `GET /playlists/{id}/items`
- **`saveUsersTracks`**: `PUT /me/tracks` → `PUT /me/library?uris=`
- **`removeUsersSavedTracks`**: `DELETE /me/tracks` → `DELETE /me/library?uris=`
- **`saveOrRemoveAlbums`**: `PUT/DELETE /me/albums` → `PUT/DELETE /me/library?uris=`
- **`checkUsersSavedAlbums`**: `GET /me/albums/contains` → `GET /me/library/contains?uris=`
- **`followArtists`**: `PUT/DELETE /me/following` → `PUT/DELETE /me/library?uris=`
- **`getAlbums`**: batch `GET /albums` replaced with parallel `GET /albums/{id}` calls
- Updated `playlist.tracks` references to `playlist.items` (field renamed in API)
- Capped search limit to 10 (API reduced max from 50)

## New tools added

| Tool | Endpoint |
|---|---|
| `followArtists` | `PUT/DELETE /me/library` (artist URIs) |
| `getFollowedArtists` | `GET /me/following` |
| `getSavedAudiobooks` | `GET /me/audiobooks` |
| `getSavedEpisodes` | `GET /me/episodes` |
| `getSavedShows` | `GET /me/shows` |
| `getUserTopItems` | `GET /me/top/{type}` |
| `getCurrentUserProfile` | `GET /me` |
| `getArtist` | `GET /artists/{id}` |
| `getArtistAlbums` | `GET /artists/{id}/albums` |
| `getTrack` | `GET /tracks/{id}` |
| `getShow` | `GET /shows/{id}` |
| `getShowEpisodes` | `GET /shows/{id}/episodes` |
| `getEpisode` | `GET /episodes/{id}` |
| `getAudiobook` | `GET /audiobooks/{id}` |
| `getAudiobookChapters` | `GET /audiobooks/{id}/chapters` |
| `getChapter` | `GET /chapters/{id}` |
| `seekToPosition` | `PUT /me/player/seek` |
| `setRepeatMode` | `PUT /me/player/repeat` |
| `toggleShuffle` | `PUT /me/player/shuffle` |
| `transferPlayback` | `PUT /me/player` |

## Other fixes

- Restored automatic token refresh (`getValidConfig()`) — tokens no longer require manual re-auth after expiry
- Added missing OAuth scopes: `user-follow-read`, `user-follow-modify`, `user-top-read`
- Removed duplicate scopes from auth flow
- Removed stale SDK instance cache and client credentials fallback

## ⚠️ Re-auth required

Users must run `npm run auth` after updating to get a token with the new scopes (`user-follow-read`, `user-follow-modify`, `user-top-read`).

## Test plan

- [x] `createPlaylist` creates a playlist and returns ID + URL
- [x] `addTracksToPlaylist` adds tracks without 403
- [x] `removeTracksFromPlaylist` removes tracks
- [x] `reorderPlaylistItems` reorders tracks
- [x] `saveUsersTracks` saves tracks to Liked Songs
- [x] `getPlaylistTracks` retrieves playlist tracks
- [x] Collaborative + public playlist returns clear error

---
_Fixes identified and implemented using [Claude Code](https://claude.com/claude-code) (claude-sonnet-4-6), tested by [@Meserlion](https://github.com/Meserlion)._