### PR TITLE
Fix 403s from Spotify Feb 2026 API migration

### DIFF
--- a/src/play.ts
+++ b/src/play.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, spotifyFetch } from './utils.js';
 
 const playMusic: tool<{
   uri: z.ZodOptional<z.ZodString>;
@@ -182,14 +182,12 @@ const createPlaylist: tool<{
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { name, description, public: isPublic = false } = args;
 
-    const result = await handleSpotifyRequest(async (spotifyApi) => {
-      const me = await spotifyApi.currentUser.profile();
-
-      return await spotifyApi.playlists.createPlaylist(me.id, {
-        name,
-        description,
-        public: isPublic,
-      });
+    const result = await spotifyFetch<{
+      id: string;
+      external_urls: { spotify: string };
+    }>('/me/playlists', {
+      method: 'POST',
+      body: { name, description, public: isPublic },
     });
 
     return {
@@ -236,12 +234,9 @@ const addTracksToPlaylist: tool<{
     try {
       const trackUris = trackIds.map((id) => `spotify:track:${id}`);
 
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.addItemsToPlaylist(
-          playlistId,
-          trackUris,
-          position,
-        );
+      await spotifyFetch(`/playlists/${playlistId}/items`, {
+        method: 'POST',
+        body: { uris: trackUris, ...(position !== undefined ? { position } : {}) },
       });
 
       return {

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, spotifyFetch } from './utils.js';
 
 const getPlaylist: tool<{
   playlistId: z.ZodString;
@@ -175,11 +175,12 @@ const removeTracksFromPlaylist: tool<{
     try {
       const tracks = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
 
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.removeItemsFromPlaylist(playlistId, {
+      await spotifyFetch(`/playlists/${playlistId}/items`, {
+        method: 'DELETE',
+        body: {
           tracks,
           ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
+        },
       });
 
       return {
@@ -246,13 +247,14 @@ const reorderPlaylistItems: tool<{
       args;
 
     try {
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.updatePlaylistItems(playlistId, {
+      await spotifyFetch(`/playlists/${playlistId}/items`, {
+        method: 'PUT',
+        body: {
           range_start: rangeStart,
           insert_before: insertBefore,
           ...(rangeLength !== undefined ? { range_length: rangeLength } : {}),
           ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
+        },
       });
 
       const count = rangeLength ?? 1;

--- a/src/read.ts
+++ b/src/read.ts
@@ -6,6 +6,7 @@ import {
   formatDuration,
   handleSpotifyRequest,
   loadSpotifyConfig,
+  spotifyFetch,
 } from './utils.js';
 
 function isTrack(item: any): item is SpotifyTrack {
@@ -277,15 +278,10 @@ const getPlaylistTracks: tool<{
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { playlistId, limit = 50, offset = 0 } = args;
 
-    const playlistTracks = await handleSpotifyRequest(async (spotifyApi) => {
-      return await spotifyApi.playlists.getPlaylistItems(
-        playlistId,
-        undefined,
-        undefined,
-        limit as MaxInt<50>,
-        offset,
-      );
-    });
+    const playlistTracks = await spotifyFetch<{
+      items: Array<{ item?: any; track?: any }>;
+      total: number;
+    }>(`/playlists/${playlistId}/items`, { query: { limit, offset } });
 
     if ((playlistTracks.items?.length ?? 0) === 0) {
       return {
@@ -299,12 +295,13 @@ const getPlaylistTracks: tool<{
     }
 
     const formattedTracks = playlistTracks.items
-      .map((item, i) => {
-        const { track } = item;
+      .map((entry, i) => {
+        // Spotify Feb 2026 migration: response uses `item` instead of `track`.
+        const track = entry.item ?? entry.track;
         if (!track) return `${offset + i + 1}. [Removed track]`;
 
         if (isTrack(track)) {
-          const artists = track.artists.map((a) => a.name).join(', ');
+          const artists = track.artists.map((a: { name: string }) => a.name).join(', ');
           const duration = formatDuration(track.duration_ms);
           return `${offset + i + 1}. "${track.name}" by ${artists} (${duration}) - ID: ${track.id}`;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,56 @@ export async function createSpotifyApi(): Promise<SpotifyApi> {
   return cachedSpotifyApi;
 }
 
+// Direct fetch against the Spotify Web API. Used for endpoints that the
+// pinned @spotify/web-api-ts-sdk targets at deprecated paths (Feb 2026
+// migration: /playlists/{id}/tracks -> /items, POST /users/{id}/playlists
+// -> POST /me/playlists). Reuses the same config + refresh logic as the SDK
+// path so tokens stay in sync.
+export async function spotifyFetch<T = unknown>(
+  path: string,
+  init: { method?: string; body?: unknown; query?: Record<string, string | number | undefined> } = {},
+): Promise<T> {
+  const config = loadSpotifyConfig();
+  if (!(config.accessToken && config.refreshToken)) {
+    throw new Error('Spotify is not authenticated. Run "npm run auth" first.');
+  }
+
+  const now = Date.now();
+  if (!config.expiresAt || config.expiresAt <= now) {
+    const tokens = await refreshAccessToken(config);
+    config.accessToken = tokens.access_token;
+    config.expiresAt = now + tokens.expires_in * 1000;
+    saveSpotifyConfig(config);
+    cachedSpotifyApi = null;
+  }
+
+  const url = new URL(`https://api.spotify.com/v1${path}`);
+  if (init.query) {
+    for (const [k, v] of Object.entries(init.query)) {
+      if (v !== undefined) url.searchParams.set(k, String(v));
+    }
+  }
+
+  const res = await fetch(url.toString(), {
+    method: init.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${config.accessToken}`,
+      ...(init.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Spotify API ${res.status} ${res.statusText}: ${text}`);
+  }
+
+  if (res.status === 204) return undefined as T;
+  const ct = res.headers.get('content-type') ?? '';
+  if (!ct.includes('application/json')) return undefined as T;
+  return (await res.json()) as T;
+}
+
 function generateRandomString(length: number): string {
   const array = new Uint8Array(length);
   crypto.getRandomValues(array);


### PR DESCRIPTION
The pinned @spotify/web-api-ts-sdk v1.2.0 targets endpoints that Spotify removed for Development Mode apps in Feb 2026. All playlist write operations and createPlaylist return 403 Forbidden. The SDK appears abandoned (last published 2 years ago), so this works around it by calling the Spotify Web API directly for the affected endpoints.

Adds spotifyFetch() helper in utils.ts that reuses the same config loading and token refresh logic as the SDK path, then migrates the five broken call sites:

  POST /users/{id}/playlists  -> POST /me/playlists
  POST /playlists/{id}/tracks -> POST /playlists/{id}/items
  PUT  /playlists/{id}/tracks -> PUT  /playlists/{id}/items
  DELETE /playlists/{id}/tracks -> DELETE /playlists/{id}/items
  GET  /playlists/{id}/tracks -> GET  /playlists/{id}/items

The new GET /items response also nests the track under "item" instead of "track", so getPlaylistTracks accepts both shapes for compatibility.

Refs marcelmarais/spotify-mcp-server#35