### PR TITLE
fix: use /playlists/{id}/items after March 2026 Spotify API migration

### DIFF
--- a/src/play.ts
+++ b/src/play.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, spotifyFetch } from './utils.js';
 
 const playMusic: tool<{
   uri: z.ZodOptional<z.ZodString>;
@@ -236,12 +236,13 @@ const addTracksToPlaylist: tool<{
     try {
       const trackUris = trackIds.map((id) => `spotify:track:${id}`);
 
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.addItemsToPlaylist(
-          playlistId,
-          trackUris,
-          position,
-        );
+      // Hit /items directly: see spotifyFetch JSDoc for context.
+      await spotifyFetch(`playlists/${playlistId}/items`, {
+        method: 'POST',
+        body: {
+          uris: trackUris,
+          ...(position !== undefined ? { position } : {}),
+        },
       });
 
       return {

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { SpotifyHandlerExtra, tool } from './types.js';
-import { handleSpotifyRequest } from './utils.js';
+import { handleSpotifyRequest, spotifyFetch } from './utils.js';
 
 const getPlaylist: tool<{
   playlistId: z.ZodString;
@@ -173,13 +173,16 @@ const removeTracksFromPlaylist: tool<{
     const { playlistId, trackIds, snapshotId } = args;
 
     try {
-      const tracks = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
+      const items = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
 
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.removeItemsFromPlaylist(playlistId, {
-          tracks,
+      // Hit /items directly: SDK targets the deprecated /tracks endpoint
+      // (see spotifyFetch JSDoc for context on the March 2026 migration).
+      await spotifyFetch(`playlists/${playlistId}/items`, {
+        method: 'DELETE',
+        body: {
+          items,
           ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
+        },
       });
 
       return {
@@ -246,13 +249,15 @@ const reorderPlaylistItems: tool<{
       args;
 
     try {
-      await handleSpotifyRequest(async (spotifyApi) => {
-        await spotifyApi.playlists.updatePlaylistItems(playlistId, {
+      // Hit /items directly: see spotifyFetch JSDoc for context.
+      await spotifyFetch(`playlists/${playlistId}/items`, {
+        method: 'PUT',
+        body: {
           range_start: rangeStart,
           insert_before: insertBefore,
           ...(rangeLength !== undefined ? { range_length: rangeLength } : {}),
           ...(snapshotId ? { snapshot_id: snapshotId } : {}),
-        });
+        },
       });
 
       const count = rangeLength ?? 1;

--- a/src/read.ts
+++ b/src/read.ts
@@ -6,6 +6,7 @@ import {
   formatDuration,
   handleSpotifyRequest,
   loadSpotifyConfig,
+  spotifyFetch,
 } from './utils.js';
 
 function isTrack(item: any): item is SpotifyTrack {
@@ -277,14 +278,17 @@ const getPlaylistTracks: tool<{
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { playlistId, limit = 50, offset = 0 } = args;
 
-    const playlistTracks = await handleSpotifyRequest(async (spotifyApi) => {
-      return await spotifyApi.playlists.getPlaylistItems(
-        playlistId,
-        undefined,
-        undefined,
-        limit as MaxInt<50>,
-        offset,
-      );
+    // Hit /items directly: see spotifyFetch JSDoc for context.
+    // Response wraps each entry's track under `item` (new) or `track` (legacy).
+    type PlaylistItemEntry = {
+      item?: SpotifyTrack | null;
+      track?: SpotifyTrack | null;
+    };
+    const playlistTracks = await spotifyFetch<{
+      items: PlaylistItemEntry[];
+      total: number;
+    }>(`playlists/${playlistId}/items`, {
+      query: { limit, offset },
     });
 
     if ((playlistTracks.items?.length ?? 0) === 0) {
@@ -299,8 +303,8 @@ const getPlaylistTracks: tool<{
     }
 
     const formattedTracks = playlistTracks.items
-      .map((item, i) => {
-        const { track } = item;
+      .map((entry, i) => {
+        const track = entry.item ?? entry.track;
         if (!track) return `${offset + i + 1}. [Removed track]`;
 
         if (isTrack(track)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,77 @@ export function saveSpotifyConfig(config: SpotifyConfig): void {
 
 let cachedSpotifyApi: SpotifyApi | null = null;
 
+/**
+ * Direct Spotify Web API fetch helper.
+ * Used to bypass @spotify/web-api-ts-sdk methods that hit deprecated endpoints
+ * (e.g. /playlists/{id}/tracks which was retired in the March 2026 API migration
+ * for new Development Mode apps; replacement is /playlists/{id}/items).
+ *
+ * Handles token loading and refresh transparently.
+ */
+export async function spotifyFetch<T = unknown>(
+  endpoint: string,
+  options: {
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+    body?: unknown;
+    query?: Record<string, string | number | undefined>;
+  } = {},
+): Promise<T> {
+  const { method = 'GET', body, query } = options;
+  const config = loadSpotifyConfig();
+
+  // Refresh token if expired
+  if (config.accessToken && config.refreshToken) {
+    const now = Date.now();
+    if (!config.expiresAt || config.expiresAt <= now) {
+      const tokens = await refreshAccessToken(config);
+      config.accessToken = tokens.access_token;
+      config.expiresAt = now + tokens.expires_in * 1000;
+      saveSpotifyConfig(config);
+      cachedSpotifyApi = null;
+    }
+  }
+
+  if (!config.accessToken) {
+    throw new Error(
+      'No access token available. Run "npm run auth" to authenticate.',
+    );
+  }
+
+  // Build URL with query string
+  const cleanEndpoint = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+  let url = `https://api.spotify.com/v1/${cleanEndpoint}`;
+  if (query) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(query)) {
+      if (v !== undefined && v !== null) qs.append(k, String(v));
+    }
+    const qsStr = qs.toString();
+    if (qsStr) url += `?${qsStr}`;
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${config.accessToken}`,
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text();
+    throw new Error(
+      `Spotify API ${method} ${url} failed (${response.status}): ${errBody}`,
+    );
+  }
+
+  // Some endpoints (DELETE, PUT) return empty body
+  const text = await response.text();
+  if (!text) return undefined as T;
+  return JSON.parse(text) as T;
+}
+
 export async function createSpotifyApi(): Promise<SpotifyApi> {
   const config = loadSpotifyConfig();
 


### PR DESCRIPTION
Spotify deprecated the /playlists/{id}/tracks endpoint family for all new Development Mode apps on March 9, 2026. The four operations affected are GET, POST, PUT, DELETE on /playlists/{id}/tracks; replacement is /items.

@spotify/web-api-ts-sdk still targets the deprecated endpoints, so any new app gets 403 Forbidden on these operations.

This patch bypasses the SDK for the four affected operations and hits the new /items endpoint directly via a small spotifyFetch() helper that handles token loading and refresh. The SDK is still used everywhere else.

Affected handlers:
  - getPlaylistTracks (read.ts)
  - addTracksToPlaylist (play.ts)
  - removeTracksFromPlaylist (playlist.ts)
  - reorderPlaylistItems (playlist.ts)

Request body changes vs the legacy endpoints:
  - POST /items uses { uris: ["spotify:track:..."] } (strings)
  - DELETE /items uses { items: [{ uri: "..." }] } (objects)
  - GET /items response uses 'item' field instead of 'track' (handler reads either for backward compatibility)

Refs:
- https://developer.spotify.com/documentation/web-api/reference/get-playlists-items
- https://developer.spotify.com/documentation/web-api/reference/remove-items-playlist
- https://community.spotify.com/t5/Spotify-for-Developers/403-Forbidden-on-all-playlist-track-requests-even-with-new-app/td-p/7367439