### PR TITLE
feat: add podcast episode and show search support

### DIFF
--- a/src/play.ts
+++ b/src/play.ts
@@ -209,38 +209,43 @@ const addTracksToPlaylist: tool<{
   position: z.ZodOptional<z.ZodNumber>;
 }> = {
   name: 'addTracksToPlaylist',
-  description: 'Add tracks to a Spotify playlist',
+  description:
+    'Add tracks or podcast episodes to a Spotify playlist. ' +
+    'Accepts Spotify track IDs, episode IDs, or full Spotify URIs (e.g. spotify:episode:xxx).',
   schema: {
     playlistId: z.string().describe('The Spotify ID of the playlist'),
-    trackIds: z.array(z.string()).describe('Array of Spotify track IDs to add'),
+    trackIds: z
+      .array(z.string())
+      .describe(
+        'Array of Spotify IDs or URIs to add. ' +
+          'Plain IDs are assumed to be tracks. ' +
+          'To add podcast episodes, pass full URIs: spotify:episode:{id}.',
+      ),
     position: z
       .number()
       .nonnegative()
       .optional()
-      .describe('Position to insert the tracks (0-based index)'),
+      .describe('Position to insert the items (0-based index)'),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { playlistId, trackIds, position } = args;
 
     if (trackIds.length === 0) {
       return {
-        content: [
-          {
-            type: 'text',
-            text: 'Error: No track IDs provided',
-          },
-        ],
+        content: [{ type: 'text', text: 'Error: No IDs provided' }],
       };
     }
 
     try {
-      const trackUris = trackIds.map((id) => `spotify:track:${id}`);
+      const uris = trackIds.map((id) =>
+        id.startsWith('spotify:') ? id : `spotify:track:${id}`,
+      );
 
       // Hit /items directly: see spotifyFetch JSDoc for context.
       await spotifyFetch(`playlists/${playlistId}/items`, {
         method: 'POST',
         body: {
-          uris: trackUris,
+          uris,
           ...(position !== undefined ? { position } : {}),
         },
       });
@@ -249,7 +254,7 @@ const addTracksToPlaylist: tool<{
         content: [
           {
             type: 'text',
-            text: `Successfully added ${trackIds.length} track${
+            text: `Successfully added ${trackIds.length} item${
               trackIds.length === 1 ? '' : 's'
             } to playlist (ID: ${playlistId})`,
           },
@@ -260,7 +265,7 @@ const addTracksToPlaylist: tool<{
         content: [
           {
             type: 'text',
-            text: `Error adding tracks to playlist: ${
+            text: `Error adding items to playlist: ${
               error instanceof Error ? error.message : String(error)
             }`,
           },

--- a/src/read.ts
+++ b/src/read.ts
@@ -1,6 +1,16 @@
 import type { MaxInt } from '@spotify/web-api-ts-sdk';
 import { z } from 'zod';
-import type { SpotifyHandlerExtra, SpotifyTrack, tool } from './types.js';
+import type {
+  SpotifyEpisode,
+  SpotifyEpisodesResponse,
+  SpotifyHandlerExtra,
+  SpotifySearchEpisodesResponse,
+  SpotifySearchShowsResponse,
+  SpotifyShow,
+  SpotifySimplifiedEpisode,
+  SpotifyTrack,
+  tool,
+} from './types.js';
 import {
   createSpotifyApi,
   formatDuration,
@@ -19,76 +29,136 @@ function isTrack(item: any): item is SpotifyTrack {
   );
 }
 
+const SEARCH_TYPES = [
+  'track',
+  'album',
+  'artist',
+  'playlist',
+  'episode',
+  'show',
+] as const;
+type SearchType = (typeof SEARCH_TYPES)[number];
+
+function formatEpisode(ep: SpotifyEpisode, i: number): string {
+  const duration = formatDuration(ep.duration_ms);
+  const date = ep.release_date ? `, ${ep.release_date}` : '';
+  const showName = ep.show?.name ?? 'Unknown show';
+  return `${i + 1}. "${ep.name}" — ${showName} (${duration}${date}) - ID: ${ep.id}`;
+}
+
+function formatShow(show: SpotifyShow, i: number): string {
+  return `${i + 1}. "${show.name}" by ${show.publisher} (${show.total_episodes} episodes) - ID: ${show.id}`;
+}
+
 const searchSpotify: tool<{
   query: z.ZodString;
-  type: z.ZodEnum<['track', 'album', 'artist', 'playlist']>;
+  type: z.ZodEnum<[SearchType, ...SearchType[]]>;
   limit: z.ZodOptional<z.ZodNumber>;
 }> = {
   name: 'searchSpotify',
-  description: 'Search for tracks, albums, artists, or playlists on Spotify',
+  description:
+    'Search for tracks, albums, artists, playlists, podcast episodes, or shows on Spotify. ' +
+    'For episodes and shows, the query matches against title, description, and publisher. ' +
+    'Use type "episode" to find individual podcast episodes by topic or guest name, ' +
+    'and type "show" to find podcast series.',
   schema: {
-    query: z.string().describe('The search query'),
-    type: z
-      .enum(['track', 'album', 'artist', 'playlist'])
+    query: z
+      .string()
       .describe(
-        'The type of item to search for either track, album, artist, or playlist',
+        'The search query. Matches title, description, and publisher for podcasts.',
+      ),
+    type: z
+      .enum(SEARCH_TYPES)
+      .describe(
+        'The type of item to search for: track, album, artist, playlist, episode (podcast episode), or show (podcast series)',
       ),
     limit: z
       .number()
       .min(1)
       .max(50)
       .optional()
-      .describe('Maximum number of results to return (10-50)'),
+      .describe('Maximum number of results to return (default: 10, max: 50)'),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { query, type, limit } = args;
     const limitValue = limit ?? 10;
 
     try {
-      const results = await handleSpotifyRequest(async (spotifyApi) => {
-        return await spotifyApi.search(
-          query,
-          [type],
-          undefined,
-          limitValue as MaxInt<50>,
-        );
-      });
-
       let formattedResults = '';
 
-      if (type === 'track' && results.tracks) {
-        formattedResults = results.tracks.items
-          .map((track, i) => {
-            const artists = track.artists.map((a) => a.name).join(', ');
-            const duration = formatDuration(track.duration_ms);
-            return `${i + 1}. "${
-              track.name
-            }" by ${artists} (${duration}) - ID: ${track.id}`;
-          })
+      if (type === 'episode') {
+        // Search returns SimplifiedEpisodeObject (no `show` field).
+        // Batch-fetch full episode objects to include show info.
+        const searchResults = await spotifyFetch<SpotifySearchEpisodesResponse>(
+          'search',
+          {
+            query: { q: query, type, limit: limitValue, market: 'from_token' },
+          },
+        );
+        const ids = searchResults.episodes.items
+          .filter((ep): ep is SpotifySimplifiedEpisode => ep !== null)
+          .map((ep) => ep.id)
+          .join(',');
+        if (!ids) {
+          formattedResults = '';
+        } else {
+          const full = await spotifyFetch<SpotifyEpisodesResponse>('episodes', {
+            query: { ids, market: 'from_token' },
+          });
+          formattedResults = full.episodes
+            .filter((ep): ep is SpotifyEpisode => ep !== null)
+            .map(formatEpisode)
+            .join('\n');
+        }
+      } else if (type === 'show') {
+        const results = await spotifyFetch<SpotifySearchShowsResponse>(
+          'search',
+          {
+            query: { q: query, type, limit: limitValue, market: 'from_token' },
+          },
+        );
+        formattedResults = results.shows.items
+          .filter((show): show is SpotifyShow => show !== null)
+          .map(formatShow)
           .join('\n');
-      } else if (type === 'album' && results.albums) {
-        formattedResults = results.albums.items
-          .map((album, i) => {
-            const artists = album.artists.map((a) => a.name).join(', ');
-            return `${i + 1}. "${album.name}" by ${artists} - ID: ${album.id}`;
-          })
-          .join('\n');
-      } else if (type === 'artist' && results.artists) {
-        formattedResults = results.artists.items
-          .map((artist, i) => {
-            return `${i + 1}. ${artist.name} - ID: ${artist.id}`;
-          })
-          .join('\n');
-      } else if (type === 'playlist' && results.playlists) {
-        formattedResults = results.playlists.items
-          .map((playlist, i) => {
-            return `${i + 1}. "${playlist?.name ?? 'Unknown Playlist'} (${
-              playlist?.description ?? 'No description'
-            } tracks)" by ${playlist?.owner?.display_name} - ID: ${
-              playlist?.id
-            }`;
-          })
-          .join('\n');
+      } else {
+        const results = await handleSpotifyRequest(async (spotifyApi) => {
+          return await spotifyApi.search(
+            query,
+            [type],
+            undefined,
+            limitValue as MaxInt<50>,
+          );
+        });
+
+        if (type === 'track' && results.tracks) {
+          formattedResults = results.tracks.items
+            .map((track, i) => {
+              const artists = track.artists.map((a) => a.name).join(', ');
+              const duration = formatDuration(track.duration_ms);
+              return `${i + 1}. "${track.name}" by ${artists} (${duration}) - ID: ${track.id}`;
+            })
+            .join('\n');
+        } else if (type === 'album' && results.albums) {
+          formattedResults = results.albums.items
+            .map((album, i) => {
+              const artists = album.artists.map((a) => a.name).join(', ');
+              return `${i + 1}. "${album.name}" by ${artists} - ID: ${album.id}`;
+            })
+            .join('\n');
+        } else if (type === 'artist' && results.artists) {
+          formattedResults = results.artists.items
+            .map((artist, i) => `${i + 1}. ${artist.name} - ID: ${artist.id}`)
+            .join('\n');
+        } else if (type === 'playlist' && results.playlists) {
+          formattedResults = results.playlists.items
+            .map((playlist, i) => {
+              return `${i + 1}. "${playlist?.name ?? 'Unknown Playlist'} (${
+                playlist?.description ?? 'No description'
+              } tracks)" by ${playlist?.owner?.display_name} - ID: ${playlist?.id}`;
+            })
+            .join('\n');
+        }
       }
 
       return {
@@ -107,9 +177,7 @@ const searchSpotify: tool<{
         content: [
           {
             type: 'text',
-            text: `Error searching for ${type}s: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
+            text: `Error searching for ${type}s: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,54 @@ export interface SpotifyTrack {
   artists: SpotifyArtist[];
   album: SpotifyAlbum;
 }
+
+export interface SpotifyEpisodeShow {
+  id: string;
+  name: string;
+}
+
+export interface SpotifyEpisode {
+  id: string;
+  name: string;
+  description: string;
+  duration_ms: number;
+  release_date: string;
+  show: SpotifyEpisodeShow | null;
+}
+
+export interface SpotifyShow {
+  id: string;
+  name: string;
+  description: string;
+  publisher: string;
+  total_episodes: number;
+}
+
+/**
+ * Simplified episode object returned by the Search API.
+ * Does not include the `show` field — use the Episodes API for full objects.
+ */
+export interface SpotifySimplifiedEpisode {
+  id: string;
+  name: string;
+  description: string;
+  duration_ms: number;
+  release_date: string;
+}
+
+export interface SpotifySearchEpisodesResponse {
+  episodes: {
+    items: Array<SpotifySimplifiedEpisode | null>;
+  };
+}
+
+/** Full episode object returned by GET /episodes, includes show info. */
+export interface SpotifyEpisodesResponse {
+  episodes: Array<SpotifyEpisode | null>;
+}
+
+export interface SpotifySearchShowsResponse {
+  shows: {
+    items: Array<SpotifyShow | null>;
+  };
+}


### PR DESCRIPTION
## Summary

Extends `searchSpotify` to support `episode` and `show` as search types, enabling podcast discovery alongside the existing track/album/artist/playlist search.

- **`src/types.ts`** — adds `SpotifyEpisode`, `SpotifyEpisodeShow`, `SpotifyShow`, `SpotifySimplifiedEpisode` and the matching response wrapper types
- **`src/read.ts`** — handles `episode` and `show` branches in `searchSpotify`; episode search uses a two-step fetch (search → `GET /episodes?ids=...`) because the Search API returns `SimplifiedEpisodeObject` which omits the `show` field
- **`src/play.ts`** — `addTracksToPlaylist` now accepts full Spotify URIs (e.g. `spotify:episode:xxx`) in addition to plain track IDs, making it possible to add podcast episodes to playlists

No changes to existing tool names, parameters, or output format for the original four search types (track, album, artist, playlist).

## Why two fetches for episodes?

The Spotify Search API returns [`SimplifiedEpisodeObject`](https://developer.spotify.com/documentation/web-api/reference/search) which does not include the `show` field. A second call to `GET /episodes?ids=...` (batched, single request) returns full `EpisodeObject` with show name and metadata. Both calls include `market=from_token` to ensure proper availability and metadata.

## Test plan

- [ ] `searchSpotify` with `type: "episode"` returns results with show name, duration, release date, and ID
- [ ] `searchSpotify` with `type: "show"` returns results with publisher, episode count, and ID
- [ ] `searchSpotify` with existing types (track, album, artist, playlist) behaves identically to before
- [ ] `addTracksToPlaylist` with `spotify:episode:xxx` URIs successfully adds podcast episodes to a playlist
- [ ] `addTracksToPlaylist` with plain track IDs continues to work as before