### PR TITLE
fix: prevent token expiry mid-session with proactive refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { albumTools } from './albums.js';
 import { playTools } from './play.js';
 import { playlistTools } from './playlist.js';
 import { readTools } from './read.js';
+import { createSpotifyApi } from './utils.js';
 
 const server = new McpServer({
   name: 'spotify-controller',
@@ -14,6 +15,19 @@ const server = new McpServer({
   (tool) => {
     server.tool(tool.name, tool.description, tool.schema, tool.handler);
   },
+);
+
+// Proactively refresh the Spotify token every 45 minutes so it never
+// expires mid-session (tokens last 60 minutes; this keeps a safe buffer).
+setInterval(
+  async () => {
+    try {
+      await createSpotifyApi();
+    } catch {
+      // Errors will surface on the next tool call; nothing actionable here.
+    }
+  },
+  45 * 60 * 1000,
 );
 
 async function main() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,7 +124,8 @@ export async function createSpotifyApi(): Promise<SpotifyApi> {
 
   if (config.accessToken && config.refreshToken) {
     const now = Date.now();
-    const shouldRefresh = !config.expiresAt || config.expiresAt <= now;
+    const shouldRefresh =
+      !config.expiresAt || config.expiresAt <= now + 5 * 60 * 1000;
 
     if (shouldRefresh) {
       console.log(
@@ -300,6 +301,7 @@ export async function authorizeSpotify(): Promise<void> {
     'user-modify-playback-state',
     'user-read-playback-state',
     'user-read-currently-playing',
+    'user-read-playback-position',
   ];
 
   const authParams = new URLSearchParams({


### PR DESCRIPTION
## Summary

- Refresh token **5 minutes before actual expiry** (was: only on expiration). Eliminates the race where a token technically valid at call-start expires during a long request.
- Add a **45-minute background interval** (`setInterval` in `index.ts`) that proactively calls `createSpotifyApi()` so idle sessions never hit an expired token on the next user interaction. Tokens live 60 minutes; 45 min keeps a safe buffer.
- Add `user-read-playback-position` to the OAuth scope list — required for reading episode progress in podcast features.

## Test plan

- [ ] Authenticate and let the server idle for 45+ minutes; confirm the next tool call succeeds without a 401
- [ ] Force `expiresAt` to `now + 3min` in the config and call any tool; confirm a refresh is triggered before the call
- [ ] Re-authorize from scratch; confirm `user-read-playback-position` appears in the granted scopes