### PR TITLE
fix: full podcast episode support in playlist tools

### DIFF
--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -288,9 +288,51 @@ const reorderPlaylistItems: tool<{
   },
 };
 
+const unfollowPlaylist: tool<{
+  playlistId: z.ZodString;
+}> = {
+  name: 'unfollowPlaylist',
+  description:
+    'Remove a playlist from the current user\'s library (unfollow). ' +
+    'Note: Spotify does not allow permanent deletion of playlists via the API.',
+  schema: {
+    playlistId: z.string().describe('The Spotify ID of the playlist to unfollow'),
+  },
+  handler: async (args, _extra: SpotifyHandlerExtra) => {
+    const { playlistId } = args;
+
+    try {
+      await spotifyFetch(`playlists/${playlistId}/followers`, {
+        method: 'DELETE',
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Successfully unfollowed playlist (ID: ${playlistId})`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error unfollowing playlist: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+      };
+    }
+  },
+};
+
 export const playlistTools = [
   getPlaylist,
   updatePlaylist,
   removeTracksFromPlaylist,
   reorderPlaylistItems,
+  unfollowPlaylist,
 ];

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -293,10 +293,12 @@ const unfollowPlaylist: tool<{
 }> = {
   name: 'unfollowPlaylist',
   description:
-    'Remove a playlist from the current user\'s library (unfollow). ' +
+    "Remove a playlist from the current user's library (unfollow). " +
     'Note: Spotify does not allow permanent deletion of playlists via the API.',
   schema: {
-    playlistId: z.string().describe('The Spotify ID of the playlist to unfollow'),
+    playlistId: z
+      .string()
+      .describe('The Spotify ID of the playlist to unfollow'),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { playlistId } = args;

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -173,7 +173,9 @@ const removeTracksFromPlaylist: tool<{
     const { playlistId, trackIds, snapshotId } = args;
 
     try {
-      const items = trackIds.map((id) => ({ uri: `spotify:track:${id}` }));
+      const items = trackIds.map((id) => ({
+        uri: id.startsWith('spotify:') ? id : `spotify:track:${id}`,
+      }));
 
       // Hit /items directly: SDK targets the deprecated /tracks endpoint
       // (see spotifyFetch JSDoc for context on the March 2026 migration).

--- a/src/read.ts
+++ b/src/read.ts
@@ -348,15 +348,16 @@ const getPlaylistTracks: tool<{
 
     // Hit /items directly: see spotifyFetch JSDoc for context.
     // Response wraps each entry's track under `item` (new) or `track` (legacy).
+    // additional_types=episode is required for Spotify to return episode objects.
     type PlaylistItemEntry = {
-      item?: SpotifyTrack | null;
-      track?: SpotifyTrack | null;
+      item?: SpotifyTrack | SpotifyEpisode | null;
+      track?: SpotifyTrack | SpotifyEpisode | null;
     };
     const playlistTracks = await spotifyFetch<{
       items: PlaylistItemEntry[];
       total: number;
     }>(`playlists/${playlistId}/items`, {
-      query: { limit, offset },
+      query: { limit, offset, additional_types: 'track,episode' },
     });
 
     if ((playlistTracks.items?.length ?? 0) === 0) {
@@ -379,6 +380,10 @@ const getPlaylistTracks: tool<{
           const artists = track.artists.map((a) => a.name).join(', ');
           const duration = formatDuration(track.duration_ms);
           return `${offset + i + 1}. "${track.name}" by ${artists} (${duration}) - ID: ${track.id}`;
+        }
+
+        if (track.type === 'episode') {
+          return formatEpisode(track as SpotifyEpisode, offset + i);
         }
 
         return `${offset + i + 1}. Unknown item`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface SpotifyEpisodeShow {
 export interface SpotifyEpisode {
   id: string;
   name: string;
+  type: 'episode';
   description: string;
   duration_ms: number;
   release_date: string;


### PR DESCRIPTION
## Summary

Follows up on #51 (episode search support) with three changes that complete the podcast episode workflow in playlist tools:

- **`playlist.ts`** — `removeTracksFromPlaylist` hard-coded `spotify:track:{id}` for all IDs, silently dropping episode URIs. Now passes full URIs through as-is; plain IDs still default to `spotify:track:{id}`.
- **`read.ts` / `types.ts`** — `getPlaylistTracks` returned "Unknown item" for podcast episodes because (1) the `/items` endpoint was called without `additional_types=track,episode`, so Spotify didn't return full episode objects, and (2) there was no episode branch in the formatter. Fixed by adding the query param, adding `type: 'episode'` to `SpotifyEpisode`, and routing episodes through the existing `formatEpisode` helper.
- **`playlist.ts`** — New `unfollowPlaylist` tool (`DELETE /playlists/{id}/followers`) to remove a playlist from the user's library. The Spotify API does not expose permanent deletion; unfollow is the closest equivalent.

## Test plan

- [ ] Add podcast episodes to a playlist via `addTracksToPlaylist` using `spotify:episode:{id}` URIs
- [ ] Call `getPlaylistTracks` — episodes should display as `"Title" — Show (duration, date) - ID: ...` instead of `Unknown item`
- [ ] Call `removeTracksFromPlaylist` with `spotify:episode:{id}` URIs — episode should be removed correctly
- [ ] Call `unfollowPlaylist` — playlist should disappear from the user's Spotify library
- [ ] Existing track behaviour unchanged (add/remove/list plain track IDs still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)