### PR TITLE
feat: include popularity score in track search results

### DIFF
--- a/src/read.ts
+++ b/src/read.ts
@@ -136,7 +136,11 @@ const searchSpotify: tool<{
             .map((track, i) => {
               const artists = track.artists.map((a) => a.name).join(', ');
               const duration = formatDuration(track.duration_ms);
-              return `${i + 1}. "${track.name}" by ${artists} (${duration}) - ID: ${track.id}`;
+              const popularity =
+                typeof track.popularity === 'number'
+                  ? `, popularity: ${track.popularity}`
+                  : '';
+              return `${i + 1}. "${track.name}" by ${artists} (${duration}${popularity}) - ID: ${track.id}`;
             })
             .join('\n');
         } else if (type === 'album' && results.albums) {


### PR DESCRIPTION
## Summary

The Spotify search API returns a `popularity` score (0–100) on every track object, but `searchSpotify` discarded it when formatting results. Surfacing it lets MCP clients rank or filter search results by popularity without a second round-trip to the API.

**Before:**
```
1. "Heaven on High" by Periphery (4:19) - ID: 7s1qpqm8n0r0FXyvgKSeqM
```

**After:**
```
1. "Heaven on High" by Periphery (4:19, popularity: 57) - ID: 7s1qpqm8n0r0FXyvgKSeqM
```

## Implementation

A one-line addition in the track formatter (`src/read.ts`), guarded with a `typeof track.popularity === 'number'` check so any context that omits the field is unaffected. No new dependencies, no API changes.

## Test Plan

The repo has no test harness, so verified manually:

- [x] `npm run typecheck` — clean (confirms `popularity` is part of the SDK track type)
- [x] `npm run lint` (biome) — clean
- [x] `npm run build` — succeeds
- [x] Live `tools/call searchSpotify` over stdio against the built server returns real scores, e.g. `"Obsession" by Periphery (3:17, popularity: 53)`

## Notes

Scope is intentionally limited to track results (the common case for ranking). Album and artist objects also carry a `popularity` field — happy to extend to those in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)