### PR TITLE
fix: always print authorization URL during auth flow

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -398,6 +398,10 @@ export async function authorizeSpotify(): Promise<void> {
         `Listening for Spotify authentication callback on port ${port}`,
       );
       console.log('Opening browser for authorization...');
+      console.log('');
+      console.log('If no browser opens, visit this URL manually:');
+      console.log(authorizationUrl);
+      console.log('');
 
       open(authorizationUrl).catch(async (_error: Error) => {
         console.log('Failed to open browser automatically.');


### PR DESCRIPTION
## Summary

`npm run auth` relies on the [`open`](https://www.npmjs.com/package/open) package to launch the browser for the OAuth consent step. On headless servers or machines without a configured default browser — common on Linux — `open` resolves **successfully without opening anything**. Because the success path never prints the URL (only the `.catch()` failure path does), the user is left staring at a silent `Listening for Spotify authentication callback on port 8888` with no way to authorize.

This bit me setting the server up on Linux: the browser never opened, no URL was printed, and the auth flow just hung.

## Fix

Print the authorization URL unconditionally, right before attempting to open the browser, so it is always available to copy manually:

```
Opening browser for authorization...

If no browser opens, visit this URL manually:
https://accounts.spotify.com/authorize?client_id=...

```

The existing `.catch()` fallback (for explicit `open` failures) is left intact.

## Test Plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [x] Ran `npm run auth` on a Linux box where `open` silently no-ops: the URL is now printed and authorization completes by pasting it into a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)