### PR TITLE
fix: create playlists via POST /me/playlists (2026 API migration)

### DIFF
--- a/src/play.ts
+++ b/src/play.ts
@@ -182,24 +182,39 @@ const createPlaylist: tool<{
   handler: async (args, _extra: SpotifyHandlerExtra) => {
     const { name, description, public: isPublic = false } = args;
 
-    const result = await handleSpotifyRequest(async (spotifyApi) => {
-      const me = await spotifyApi.currentUser.profile();
-
-      return await spotifyApi.playlists.createPlaylist(me.id, {
-        name,
-        description,
-        public: isPublic,
+    try {
+      // Hit /me/playlists directly: the /users/{id}/playlists path the SDK's
+      // createPlaylist() uses was retired in the March 2026 API migration for
+      // Development Mode apps (see spotifyFetch JSDoc). POST /me/playlists
+      // infers the owner from the token, so no profile lookup is needed.
+      const result = await spotifyFetch<{
+        id: string;
+        external_urls: { spotify: string };
+      }>('me/playlists', {
+        method: 'POST',
+        body: { name, description, public: isPublic },
       });
-    });
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Successfully created playlist "${name}"\nPlaylist ID: ${result.id}\nPlaylist URL: ${result.external_urls.spotify}`,
-        },
-      ],
-    };
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Successfully created playlist "${name}"\nPlaylist ID: ${result.id}\nPlaylist URL: ${result.external_urls.spotify}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error creating playlist: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+      };
+    }
   },
 };
 


### PR DESCRIPTION
## What

`createPlaylist` still calls the SDK's `playlists.createPlaylist(userId, …)`, which targets the deprecated `POST /v1/users/{user_id}/playlists` endpoint. For Development Mode apps, after the 2026 Web API migration that endpoint now returns a bare `403 Forbidden`, so playlist creation fails even when the token carries valid `playlist-modify-private` / `playlist-modify-public` scopes.

This is the same class of change #50 already handled for playlist items (`/tracks` → `/items`) and library writes (`/me/library`). `createPlaylist` was just missed in that pass — it's the one remaining write that still hits a retired endpoint.

## Change

Route `createPlaylist` through the existing `spotifyFetch` helper to `POST /me/playlists`. `POST /me/playlists` infers the owner from the access token, so the extra `currentUser.profile()` round-trip is no longer needed. Error handling now mirrors the sibling `addTracksToPlaylist` handler.

## Testing

Verified against a Development Mode app with a token carrying `playlist-modify-*`:

- `POST /v1/users/{id}/playlists` → `403 Forbidden` (confirms the deprecation)
- `POST /v1/me/playlists` → `201 Created`
- create playlist + add items end-to-end → playlist created with tracks
