### PR TITLE
fix: handle Spotify refresh tokens expiring after 6 months (invalid_grant)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -254,10 +254,37 @@ async function refreshAccessToken(
 
   if (!response.ok) {
     const errorData = await response.text();
+    let errorCode: string | undefined;
+    try {
+      errorCode = JSON.parse(errorData).error;
+    } catch {
+      // Non-JSON error body; treat as a generic, retryable failure.
+    }
+
+    // An expired (after 6 months) or revoked refresh token returns
+    // invalid_grant. Discard the stored tokens so we never retry them; the
+    // user has to sign in again to get a new refresh token.
+    if (errorCode === 'invalid_grant') {
+      config.accessToken = undefined;
+      config.refreshToken = undefined;
+      config.expiresAt = undefined;
+      saveSpotifyConfig(config);
+      throw new Error(
+        'Spotify refresh token is no longer valid (invalid_grant) and has been discarded. Please run "npm run auth" to re-authenticate.',
+      );
+    }
+
     throw new Error(`Failed to refresh access token: ${errorData}`);
   }
 
   const data = await response.json();
+
+  // Spotify may rotate the refresh token on refresh; persist the new one so
+  // the caller's saveSpotifyConfig() writes it back.
+  if (data.refresh_token) {
+    config.refreshToken = data.refresh_token;
+  }
+
   return {
     access_token: data.access_token,
     expires_in: data.expires_in || 3600,


### PR DESCRIPTION
## What

Starting **July 20, 2026**, Spotify refresh tokens expire six months after the user's original authorization ([Developer Blog, 2026-06-18](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration)). Once a refresh token expires, the token endpoint returns `{"error": "invalid_grant"}`, and the app must discard the stored token and send the user through sign-in again — without retrying.

Today `refreshAccessToken()` treats any non-OK response as a generic error and leaves the dead refresh token in `spotify-config.json`. Every later call — including the 45-minute proactive refresh — retries the same invalid token and fails, leaving the user stuck until they manually wipe the config.

## Change

All contained in `refreshAccessToken()` (`src/utils.ts`):

- **Detect `invalid_grant`** by parsing the token endpoint's error body.
- **Discard the stored token**: clear `accessToken` / `refreshToken` / `expiresAt` from the config file and throw a clear error instructing the user to run `npm run auth`. The dead token is never retried.
- **Defensive**: if Spotify ever returns a rotated `refresh_token` on a successful refresh, persist it. Per the blog, Spotify does not currently do this, so this is forward-compatibility insurance rather than required behavior — but it avoids silently dropping a valid token should that change.

Non-`invalid_grant` failures keep the existing generic, retryable behavior. The Client Credentials flow is unaffected (the blog confirms it is out of scope).

## Why it's minimal

The fix lives entirely in `refreshAccessToken()`. Both callers (`spotifyFetch`, `createSpotifyApi`) are unchanged: the rotated token is persisted by mutating the `config` object they already pass to `saveSpotifyConfig()`. Re-authentication remains the existing, deliberate `npm run auth` step — appropriate for a background MCP server that should not auto-launch a browser from inside a tool call.

## Testing

- `npm run typecheck` — pass
- `npm run lint` (biome) — pass
- Integration test against the live Spotify token endpoint: forcing a refresh with a bogus refresh token returns `invalid_grant`; the tokens are cleared from `spotify-config.json`, the client credentials are preserved, and the re-auth error is surfaced. A normal refresh still succeeds.
