### PR TITLE
fix: log token refresh messages to stderr (stdout corrupts MCP stream)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,7 +129,7 @@ export async function createSpotifyApi(): Promise<SpotifyApi> {
       !config.expiresAt || config.expiresAt <= now + 5 * 60 * 1000;
 
     if (shouldRefresh) {
-      console.log(
+      console.error(
         'Access token expired or missing expiration time, refreshing...',
       );
       try {
@@ -137,7 +137,7 @@ export async function createSpotifyApi(): Promise<SpotifyApi> {
         config.accessToken = tokens.access_token;
         config.expiresAt = now + tokens.expires_in * 1000; // Convert seconds to milliseconds
         saveSpotifyConfig(config);
-        console.log('Access token refreshed successfully');
+        console.error('Access token refreshed successfully');
 
         // Clear cached API instance to force recreation with new token
         cachedSpotifyApi = null;


### PR DESCRIPTION
## Problem

MCP servers using the stdio transport must emit **only JSON-RPC on stdout** — anything else corrupts the protocol stream. The token refresh path in `createSpotifyApi()` (`src/utils.ts`) logs two messages with `console.log`:

- `Access token expired or missing expiration time, refreshing...`
- `Access token refreshed successfully`

Since this path runs inside the server process whenever the cached access token has expired (or is within 5 minutes of expiring), any client connecting after ~1 hour of inactivity crashes while parsing the stream. Claude Desktop fails with:

```
Unexpected token 'A', "Access tok"... is not valid JSON
```

The failure looks intermittent because each failed connection attempt still refreshes and saves a valid token — so an immediate retry succeeds, and the error only returns once the token expires again.

## Fix

Route both messages to `console.error` (stderr), matching the existing error logging in the same function. Clients log stderr harmlessly.

## Verification

Reproduced by forcing `expiresAt` into the past in `spotify-config.json`, then driving the built server over stdio with `initialize` + a `searchSpotify` tool call and validating every stdout line as JSON:

- **Before:** both refresh messages appear on stdout between JSON-RPC frames (client parse error).
- **After:** stdout is pure JSON-RPC, refresh messages appear on stderr, and the tool call succeeds against the live Spotify API.
