### PR TITLE
fix: cap search limit at 10 and add offset param

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ A lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io) se
    - **Parameters**:
      - `query` (string): The search term
      - `type` (string): Type of item to search for (track, album, artist, playlist)
-     - `limit` (number, optional): Maximum number of results to return (10-50)
+     - `limit` (number, optional): Maximum number of results to return (1-10, default: 10)
+     - `offset` (number, optional): Index of the first result to return (default: 0)
    - **Returns**: List of matching items with their IDs, names, and additional details
-   - **Example**: `searchSpotify("bohemian rhapsody", "track", 20)`
+   - **Example**: `searchSpotify("bohemian rhapsody", "track", 10)`
 
 2. **getNowPlaying**
 

--- a/src/read.ts
+++ b/src/read.ts
@@ -54,6 +54,7 @@ const searchSpotify: tool<{
   query: z.ZodString;
   type: z.ZodEnum<[SearchType, ...SearchType[]]>;
   limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
 }> = {
   name: 'searchSpotify',
   description:
@@ -75,13 +76,21 @@ const searchSpotify: tool<{
     limit: z
       .number()
       .min(1)
-      .max(50)
+      .max(10)
       .optional()
-      .describe('Maximum number of results to return (default: 10, max: 50)'),
+      .describe('Maximum number of results to return (default: 10, max: 10)'),
+    offset: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Index of the first result to return (default: 0). Combine with limit to page past the first 10 results.',
+      ),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
-    const { query, type, limit } = args;
+    const { query, type, limit, offset } = args;
     const limitValue = limit ?? 10;
+    const offsetValue = offset ?? 0;
 
     try {
       let formattedResults = '';
@@ -92,7 +101,13 @@ const searchSpotify: tool<{
         const searchResults = await spotifyFetch<SpotifySearchEpisodesResponse>(
           'search',
           {
-            query: { q: query, type, limit: limitValue, market: 'from_token' },
+            query: {
+              q: query,
+              type,
+              limit: limitValue,
+              offset: offsetValue,
+              market: 'from_token',
+            },
           },
         );
         const ids = searchResults.episodes.items
@@ -114,7 +129,13 @@ const searchSpotify: tool<{
         const results = await spotifyFetch<SpotifySearchShowsResponse>(
           'search',
           {
-            query: { q: query, type, limit: limitValue, market: 'from_token' },
+            query: {
+              q: query,
+              type,
+              limit: limitValue,
+              offset: offsetValue,
+              market: 'from_token',
+            },
           },
         );
         formattedResults = results.shows.items
@@ -128,6 +149,7 @@ const searchSpotify: tool<{
             [type],
             undefined,
             limitValue as MaxInt<50>,
+            offsetValue,
           );
         });
 


### PR DESCRIPTION
Spotify dropped the search `limit` max from 50 to 10 in the February 2026 API changes, so anything above 10 gets rejected. The zod schema still allows up to 50 and the tool description tells the model "max: 50", which makes the model ask for values that fail.

Caps `limit` at 10 and fixes the description. Also adds an `offset` param, since with a max of 10 there was no way to reach results past the first page.

Ref: https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide

Typecheck and lint pass.