### PR TITLE
fix: request playlist-read-collaborative scope

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -320,16 +320,14 @@ export async function authorizeSpotify(): Promise<void> {
     'user-read-playback-state',
     'user-modify-playback-state',
     'user-read-currently-playing',
+    'user-read-playback-position',
     'playlist-read-private',
+    'playlist-read-collaborative',
     'playlist-modify-private',
     'playlist-modify-public',
     'user-library-read',
     'user-library-modify',
     'user-read-recently-played',
-    'user-modify-playback-state',
-    'user-read-playback-state',
-    'user-read-currently-playing',
-    'user-read-playback-position',
     'user-top-read',
   ];
 


### PR DESCRIPTION
Collaborative playlists never show up in `getMyPlaylists` because `playlist-read-collaborative` is not in the requested scopes. Adding it so they come back like private ones do.

Also removes `user-modify-playback-state`, `user-read-playback-state` and `user-read-currently-playing` from the list, they were each in there twice.

Note this needs a re-auth to take effect, existing tokens keep the old scope set.

Typecheck and lint pass.