### PR TITLE
fix: playlist track counts always reported as 0 in getMyPlaylists

### DIFF
--- a/src/read.ts
+++ b/src/read.ts
@@ -330,7 +330,13 @@ const getMyPlaylists: tool<{
 
     const formattedPlaylists = playlists.items
       .map((playlist, i) => {
-        const tracksTotal = playlist.tracks?.total ? playlist.tracks.total : 0;
+        // /me/playlists returns the track container as `items` since the March
+        // 2026 migration; older responses (and the SDK types) still say `tracks`.
+        const counts = playlist as unknown as {
+          tracks?: { total?: number };
+          items?: { total?: number };
+        };
+        const tracksTotal = counts.tracks?.total ?? counts.items?.total ?? 0;
         return `${i + 1}. "${playlist.name}" (${tracksTotal} tracks) - ID: ${
           playlist.id
         }`;


### PR DESCRIPTION
## The bug

`getMyPlaylists` reports every playlist as `0 tracks`:

```
1. "Afrikaans" (0 tracks) - ID: 0zNUw3mkJReyYKD85Bw1fU
2. "Motivation" (0 tracks) - ID: 3ttHhApN9bYODGhhKU8u3I
```

Those playlists have 170 and 22 tracks.

## Cause

`src/read.ts` reads `playlist.tracks?.total`. Since the March 2026 API migration,
`/me/playlists` returns the track container as `items`, not `tracks` — the same
rename this codebase already handles for the playlist item endpoints (`spotifyFetch`
calls `playlists/{id}/items` with a comment about exactly this). So `tracks` is
undefined and the existing ternary falls through to `0`.

## Fix

Read `tracks.total` first, fall back to `items.total`. Both the current and older
response shapes work, so this is safe if the field is ever served either way.

## Verification

Built and driven over stdio against a live account:

```
1. "Audio Well Journey: 3 - Energise" (10 tracks)
2. "Shepherd Fees" (154 tracks)
3. "Shepherd Wedding" (7 tracks)
4. "S+L" (7 tracks)
5. "Afrikaans" (170 tracks)
6. "Motivation" (22 tracks)
```

Counts match the playlists. `npm run build` and `npm run typecheck` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)