### PR TITLE
fix: playlist track counts always show 0

### DIFF
--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -21,7 +21,16 @@ const getPlaylist: tool<{
 
       const owner =
         playlist.owner?.display_name ?? playlist.owner?.id ?? 'Unknown';
-      const tracksTotal = playlist.tracks?.total ?? 0;
+      // The March 2026 API migration dropped the embedded `tracks` paging
+      // object from GET /playlists/{id} for Development Mode apps (replaced
+      // by a top-level `items` field of the same shape) — fetch the count
+      // directly instead of trusting playlist.tracks.total, which is always
+      // undefined now. See spotifyFetch JSDoc for more context.
+      const trackCount = await spotifyFetch<{ total: number }>(
+        `playlists/${playlistId}/items`,
+        { query: { limit: 1, fields: 'total' } },
+      ).catch(() => ({ total: playlist.tracks?.total ?? 0 }));
+      const tracksTotal = trackCount.total ?? 0;
       const isPublic = playlist.public ? 'Public' : 'Private';
       const isCollaborative = playlist.collaborative ? ' | Collaborative' : '';
       const description = playlist.description

--- a/src/read.ts
+++ b/src/read.ts
@@ -328,9 +328,19 @@ const getMyPlaylists: tool<{
       };
     }
 
+    // GET /me/playlists no longer embeds a tracks count at all post-migration
+    // (see spotifyFetch JSDoc) — fetch each playlist's real count directly.
+    const trackCounts = await Promise.all(
+      playlists.items.map((playlist) =>
+        spotifyFetch<{ total: number }>(`playlists/${playlist.id}/items`, {
+          query: { limit: 1, fields: 'total' },
+        }).catch(() => ({ total: playlist.tracks?.total ?? 0 })),
+      ),
+    );
+
     const formattedPlaylists = playlists.items
       .map((playlist, i) => {
-        const tracksTotal = playlist.tracks?.total ? playlist.tracks.total : 0;
+        const tracksTotal = trackCounts[i]?.total ?? 0;
         return `${i + 1}. "${playlist.name}" (${tracksTotal} tracks) - ID: ${
           playlist.id
         }`;


### PR DESCRIPTION
## Summary
- `getPlaylist` and `getMyPlaylists` always reported 0 tracks for every playlist, regardless of actual content.
- Root cause: the March 2026 API migration dropped the embedded `tracks` paging object from `GET /playlists/{id}` and `GET /me/playlists` for Development Mode apps — confirmed by inspecting the raw API response, which now has a top-level `items` field on the single-playlist endpoint and no track count at all on the list endpoint. `playlist.tracks?.total` is therefore always `undefined`.
- Fix: fetch the real count from `/playlists/{id}/items?limit=1&fields=total` (minimal payload) in both tools, falling back to the old field / `0` if that request fails (e.g. 403 on restricted/editorial playlists), so the tools degrade gracefully instead of erroring out.

## Test plan
- [x] `npm run build` — no type errors
- [x] Verified against live Spotify data: a playlist with 9 known tracks now reports "Tracks: 9" via both `getPlaylist` and `getMyPlaylists` (previously "0 tracks" for all 50+ playlists in the account tested)
- [x] Verified graceful fallback on a 403-restricted editorial playlist (no crash, falls back to 0)