### PR TITLE
fix: add offset param to getMyPlaylists

### DIFF
--- a/src/read.ts
+++ b/src/read.ts
@@ -297,6 +297,7 @@ const getNowPlaying: tool<Record<string, never>> = {
 
 const getMyPlaylists: tool<{
   limit: z.ZodOptional<z.ZodNumber>;
+  offset: z.ZodOptional<z.ZodNumber>;
 }> = {
   name: 'getMyPlaylists',
   description: "Get a list of the current user's playlists on Spotify",
@@ -307,13 +308,19 @@ const getMyPlaylists: tool<{
       .max(50)
       .optional()
       .describe('Maximum number of playlists to return (1-50)'),
+    offset: z
+      .number()
+      .min(0)
+      .optional()
+      .describe('Offset for pagination (0-based index)'),
   },
   handler: async (args, _extra: SpotifyHandlerExtra) => {
-    const { limit = 50 } = args;
+    const { limit = 50, offset = 0 } = args;
 
     const playlists = await handleSpotifyRequest(async (spotifyApi) => {
       return await spotifyApi.currentUser.playlists.playlists(
         limit as MaxInt<50>,
+        offset,
       );
     });
 
@@ -322,7 +329,10 @@ const getMyPlaylists: tool<{
         content: [
           {
             type: 'text',
-            text: "You don't have any playlists on Spotify",
+            text:
+              offset > 0
+                ? `No playlists found at offset ${offset} (you have ${playlists.total} in total)`
+                : "You don't have any playlists on Spotify",
           },
         ],
       };
@@ -337,7 +347,7 @@ const getMyPlaylists: tool<{
           items?: { total?: number };
         };
         const tracksTotal = counts.tracks?.total ?? counts.items?.total ?? 0;
-        return `${i + 1}. "${playlist.name}" (${tracksTotal} tracks) - ID: ${
+        return `${offset + i + 1}. "${playlist.name}" (${tracksTotal} tracks) - ID: ${
           playlist.id
         }`;
       })
@@ -347,7 +357,9 @@ const getMyPlaylists: tool<{
       content: [
         {
           type: 'text',
-          text: `# Your Spotify Playlists\n\n${formattedPlaylists}`,
+          text: `# Your Spotify Playlists (${offset + 1}-${
+            offset + playlists.items.length
+          } of ${playlists.total})\n\n${formattedPlaylists}`,
         },
       ],
     };


### PR DESCRIPTION
`getMyPlaylists` accepts only `limit` (max 50) and calls `currentUser.playlists.playlists(limit)`. The SDK signature is `playlists(limit?, offset?)` — the second argument was simply never passed, so there is no way to reach a playlist past the first 50.

The output compounds it. The header is a bare `# Your Spotify Playlists` with no total, and items are numbered from 1 on every call. On an account with 246 playlists the model receives 50 with no indication the other 196 exist, so it presents that page as the complete list.

Adds an `offset` param mirroring `getUsersSavedTracks`, threads it into the SDK call, offsets the item numbering, and reports the range in the header (`# Your Spotify Playlists (51-100 of 246)`) so the caller can tell whether to page again. The empty-result branch now distinguishes "you have no playlists" from "you paged past the end". `offset` is optional and defaults to 0, so existing callers are unaffected.

This is the same fix #68 made for `searchSpotify` and #19 for `getPlaylistTracks` — `getMyPlaylists` was the remaining library listing without pagination.

Verified against a live account with 246 playlists: sequential pages return distinct, correctly numbered entries with an accurate total, an out-of-range `offset` returns the new message, and calling with no arguments behaves exactly as before. Typecheck and lint pass.
